### PR TITLE
Fix a rotation bug

### DIFF
--- a/Assets/RubiksCubeModule.cs
+++ b/Assets/RubiksCubeModule.cs
@@ -482,6 +482,8 @@ public class RubiksCubeModule : MonoBehaviour
 
         if (command.Trim().Equals("rotate", StringComparison.InvariantCultureIgnoreCase))
         {
+            yield return null;
+
             bool frontFace = transform.root.eulerAngles.z < 1;  //eulerAngles.z = 0 on front face, 180 on back face.
             const int angle = 60;
 


### PR DESCRIPTION
The bug was caused by the command being processed before the bomb has rotated to the correct face the module was on, resulting in some instances the rotate tilting the module tilting towards the back face instead of the front face.

Another good reason to do a yield return null before you begin processing commands.