### PR TITLE
Rubik's cube rotate command changes

### DIFF
--- a/Assets/RubiksCube.unity
+++ b/Assets/RubiksCube.unity
@@ -1,19 +1,19 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
 --- !u!29 &1
-SceneSettings:
+OcclusionCullingSettings:
   m_ObjectHideFlags: 0
-  m_PVSData: 
-  m_PVSObjectsArray: []
-  m_PVSPortalsArray: []
+  serializedVersion: 2
   m_OcclusionBakeSettings:
     smallestOccluder: 5
     smallestHole: 0.25
     backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 7
+  serializedVersion: 8
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -25,6 +25,7 @@ RenderSettings:
   m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
   m_AmbientIntensity: 1
   m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
   m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
   m_HaloStrength: 0.5
   m_FlareStrength: 1
@@ -37,11 +38,11 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.37356392, g: 0.38112, b: 0.35887662, a: 1}
+  m_IndirectSpecularColor: {r: 0.37312672, g: 0.3807464, b: 0.35872698, a: 1}
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 7
+  serializedVersion: 11
   m_GIWorkflowMode: 0
   m_GISettings:
     serializedVersion: 2
@@ -53,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 1
   m_LightmapEditorSettings:
-    serializedVersion: 4
+    serializedVersion: 9
     m_Resolution: 2
     m_BakeResolution: 40
     m_TextureWidth: 1024
@@ -66,39 +67,56 @@ LightmapSettings:
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
     m_TextureCompression: 1
-    m_DirectLightInLightProbes: 1
     m_FinalGather: 0
     m_FinalGatherFiltering: 1
     m_FinalGatherRayCount: 256
     m_ReflectionCompression: 2
+    m_MixedBakeMode: 1
+    m_BakeBackend: 0
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVRFiltering: 0
+    m_PVRFilteringMode: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousColorSigma: 1
+    m_PVRFilteringAtrousNormalSigma: 1
+    m_PVRFilteringAtrousPositionSigma: 1
   m_LightingDataAsset: {fileID: 0}
-  m_RuntimeCPUUsage: 25
+  m_UseShadowmask: 0
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
   m_ObjectHideFlags: 0
   m_BuildSettings:
     serializedVersion: 2
+    agentTypeID: 0
     agentRadius: 0.5
     agentHeight: 2
     agentSlope: 45
     agentClimb: 0.4
     ledgeDropHeight: 0
     maxJumpAcrossDistance: 0
-    accuratePlacement: 0
     minRegionArea: 2
-    cellSize: 0.16666667
     manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
   m_NavMeshData: {fileID: 0}
 --- !u!1 &539924550
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 539924552}
-  - 108: {fileID: 539924551}
+  - component: {fileID: 539924552}
+  - component: {fileID: 539924551}
   m_Layer: 0
   m_Name: Lamp
   m_TagString: Untagged
@@ -113,7 +131,7 @@ Light:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 539924550}
   m_Enabled: 1
-  serializedVersion: 7
+  serializedVersion: 8
   m_Type: 2
   m_Color: {r: 1, g: 0.9607843, b: 0.8901961, a: 1}
   m_Intensity: 2.7
@@ -138,6 +156,22 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_FalloffTable:
+    m_Table[0]: 0
+    m_Table[1]: 0
+    m_Table[2]: 0
+    m_Table[3]: 0
+    m_Table[4]: 0
+    m_Table[5]: 0
+    m_Table[6]: 0
+    m_Table[7]: 0
+    m_Table[8]: 0
+    m_Table[9]: 0
+    m_Table[10]: 0
+    m_Table[11]: 0
+    m_Table[12]: 0
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!4 &539924552
@@ -149,22 +183,22 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -1.089771, y: 0.9635483, z: 0.5165237}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &545369960
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 545369965}
-  - 20: {fileID: 545369964}
-  - 92: {fileID: 545369963}
-  - 124: {fileID: 545369962}
-  - 81: {fileID: 545369961}
+  - component: {fileID: 545369965}
+  - component: {fileID: 545369964}
+  - component: {fileID: 545369963}
+  - component: {fileID: 545369962}
+  - component: {fileID: 545369961}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -223,6 +257,8 @@ Camera:
   m_TargetDisplay: 0
   m_TargetEye: 3
   m_HDR: 0
+  m_AllowMSAA: 1
+  m_ForceIntoRT: 0
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
@@ -234,12 +270,12 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 545369960}
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 0.3, z: 0}
+  m_LocalPosition: {x: -0.003, y: 0.3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!1001 &605902728
 Prefab:
   m_ObjectHideFlags: 0

--- a/Assets/RubiksCubeModule.cs
+++ b/Assets/RubiksCubeModule.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using Boo.Lang.Runtime;
+using Newtonsoft.Json;
 using RubiksCube;
 using UnityEngine;
 
@@ -14,6 +17,7 @@ public class RubiksCubeModule : MonoBehaviour
     public KMBombInfo Bomb;
     public KMBombModule Module;
     public KMAudio Audio;
+    public KMModSettings Settings;
     public KMSelectable MainSelectable;
 
     public KMSelectable Reset;
@@ -39,6 +43,8 @@ public class RubiksCubeModule : MonoBehaviour
 
     private int _moduleId;
     private static int _moduleIdCounter = 1;
+
+    private RubiksCubeSettings _modSettings = null;
 
     sealed class Pusher
     {
@@ -72,6 +78,46 @@ public class RubiksCubeModule : MonoBehaviour
             obj.transform.localPosition = LocalPosition;
             obj.transform.localScale = new Vector3(1, 1, 1);
             return obj;
+        }
+    }
+
+    public class RubiksCubeSettings
+    {
+        public string HowToUse1 = "This Setting determines how the Cube rotation works in Twitch Plays";
+        public string HowToUse2 = "The original method Rotates the bomb in order to view the cube sides. (and as of now, whatever side camera view that is active on that module)";
+        public string HowToUse3 = "The New method actually rotates the cube itself in order to view the sides.";
+        public bool UseOriginalTwitchPlaysRotationMethod = true;
+
+        private static bool _firstTime = true;
+        public static void WriteSettings(KMModSettings settings, RubiksCubeSettings rubiksCubeSettings)
+        {
+            if (!_firstTime) return;
+            try
+            {
+                File.WriteAllText(settings.SettingsPath, JsonConvert.SerializeObject(rubiksCubeSettings, Formatting.Indented));
+                _firstTime = false;
+            }
+            catch
+            {
+                //
+            }
+        }
+
+        public static RubiksCubeSettings ReadSettings(KMModSettings settings)
+        {
+            RubiksCubeSettings rubiksCubeSettings;
+            try
+            {
+                rubiksCubeSettings = File.Exists(settings.SettingsPath) 
+                    ? JsonConvert.DeserializeObject<RubiksCubeSettings>(File.ReadAllText(settings.SettingsPath)) 
+                    : new RubiksCubeSettings();
+            }
+            catch
+            {
+                rubiksCubeSettings = new RubiksCubeSettings();
+            }
+            WriteSettings(settings, rubiksCubeSettings);
+            return rubiksCubeSettings;
         }
     }
 
@@ -283,6 +329,8 @@ public class RubiksCubeModule : MonoBehaviour
                 }
                 return true;
             };
+
+            _modSettings = RubiksCubeSettings.ReadSettings(Settings);
         };
     }
 
@@ -487,6 +535,68 @@ public class RubiksCubeModule : MonoBehaviour
         return rate * (Time.deltaTime / targetTime);
     }
 
+    IEnumerator OriginalRotate()
+    {
+        yield return null;
+        //Bomb rotation requires Quaternion.Euler(x,0,0) * Quaternion.Euler(0,y,0) * Quaternion.Euler(0,0,z)
+        //Camera view rotation requires Quaternion.Euler(x,y,z)
+        //The new format for this requires returning a Quaterion[] array containing the above two specifcations in that order.
+
+        bool frontFace = transform.root.eulerAngles.z > -50 && transform.root.eulerAngles.z < 50;  //eulerAngles.z = 0 on front face, 180 on back face.
+        const int angle = 60;
+
+        for (float i = 0; i <= angle; i += getRotateRate(0.5f, 150))
+        {
+            yield return frontFace
+                ? new[] { Quaternion.Euler(easeInOutQuad(i, 0, angle, angle), 0, 0), Quaternion.Euler(easeInOutQuad(i, 0, angle, angle), 0, 0) }
+                : new[] { Quaternion.Euler(easeInOutQuad(i, 0, -angle, angle), 0, 0), Quaternion.Euler(easeInOutQuad(i, 0, -angle, angle), 0, 0) };
+            yield return null;
+        }
+        for (float i = 0; i <= 360; i += getRotateRate(10, 750))
+        {
+            yield return frontFace
+                ? new[] { Quaternion.Euler(angle, 0, 0) * Quaternion.Euler(0, easeInOutQuad(i, 0, 360, 360), 0), Quaternion.Euler(angle, easeInOutQuad(i, 0, 360, 360), 0) }
+                : new[] { Quaternion.Euler(-angle, 0, 0) * Quaternion.Euler(0, easeInOutQuad(i, 0, -360, 360), 0), Quaternion.Euler(angle, easeInOutQuad(i, 0, -360, 360), 0) };
+            yield return null;
+        }
+        for (float i = 0; i <= angle; i += getRotateRate(0.5f, 150))
+        {
+            yield return frontFace
+                ? new[] { Quaternion.Euler(easeInOutQuad(i, angle, 0, angle), 0, 0) , Quaternion.Euler(easeInOutQuad(i, angle, 0, angle), 0, 0) }
+                : new[] { Quaternion.Euler(easeInOutQuad(i, -angle, 0, angle), 0, 0) , Quaternion.Euler(easeInOutQuad(i, -angle, 0, angle), 0, 0) };
+            yield return null;
+        }
+        yield return Quaternion.Euler(0, 0, 0);
+    }
+
+    IEnumerator NewRotate()
+    {
+        yield return null;
+        const int angle = 75;
+        var Cube = OnAxis.parent;
+
+        for (float i = 0; i < angle; i += getRotateRate(2, 300))
+        {
+            Cube.localEulerAngles = new Vector3(30 - i, 65 + ((i / angle) * 55), 55 - ((i / angle) * 10));
+            yield return null;
+        }
+        Cube.localEulerAngles = new Vector3(Mathf.Round(-45), Mathf.Round(120), Mathf.Round(45));
+        yield return new WaitForSeconds(2f);
+        for (float i = 0; i < angle; i += getRotateRate(2, 300))
+        {
+            Cube.localEulerAngles = new Vector3(-45 + i, 120 - ((i / angle) * 55), 45 + ((i / angle) * 100));
+            yield return null;
+        }
+        Cube.localEulerAngles = new Vector3(Mathf.Round(30), Mathf.Round(65), Mathf.Round(145));
+        yield return new WaitForSeconds(2f);
+        for (float i = 0; i < angle; i += getRotateRate(2, 300))
+        {
+            Cube.localEulerAngles = new Vector3(Mathf.Round(30), Mathf.Round(65), 145 - ((i / angle) * 90));
+            yield return null;
+        }
+        Cube.localEulerAngles = new Vector3(Mathf.Round(30), Mathf.Round(65), Mathf.Round(55));
+    }
+
     IEnumerator ProcessTwitchCommand(string command)
     {
         if (_isSolved)
@@ -494,6 +604,7 @@ public class RubiksCubeModule : MonoBehaviour
 
         if (command.Trim().Equals("reset", StringComparison.InvariantCultureIgnoreCase))
         {
+            yield return null;
             Reset.OnInteract();
             yield return new WaitForSeconds(.1f);
             yield break;
@@ -502,32 +613,11 @@ public class RubiksCubeModule : MonoBehaviour
         if (command.Trim().Equals("rotate", StringComparison.InvariantCultureIgnoreCase))
         {
             yield return null;
-
-            bool frontFace = transform.root.eulerAngles.z < 1;  //eulerAngles.z = 0 on front face, 180 on back face.
-            const int angle = 60;
-
-            for (float i = 0; i <= angle; i += getRotateRate(0.5f, 150))
-            {
-                yield return frontFace
-                    ? Quaternion.Euler(easeInOutQuad(i, 0, angle, angle), 0, 0)
-                    : Quaternion.Euler(easeInOutQuad(i, 0, -angle, angle), 0, 0);
-                yield return null;
-            }
-            for (float i = 0; i <= 360; i += getRotateRate(10, 750))
-            {
-                yield return frontFace
-                    ? Quaternion.Euler(angle, 0, 0) * Quaternion.Euler(0, easeInOutQuad(i, 0, 360, 360), 0)
-                    : Quaternion.Euler(-angle, 0, 0) * Quaternion.Euler(0, easeInOutQuad(i, 0, -360, 360), 0);
-                yield return null;
-            }
-            for (float i = 0; i <= angle; i += getRotateRate(0.5f, 150))
-            {
-                yield return frontFace
-                    ? Quaternion.Euler(easeInOutQuad(i, angle, 0, angle), 0, 0)
-                    : Quaternion.Euler(easeInOutQuad(i, -angle, 0, angle), 0, 0);
-                yield return null;
-            }
-            yield return Quaternion.Euler(0, 0, 0);
+            var rotateMethod = _modSettings.UseOriginalTwitchPlaysRotationMethod
+                ? OriginalRotate()
+                : NewRotate();
+            while(rotateMethod.MoveNext())
+                yield return rotateMethod.Current;
             yield break;
         }
 
@@ -559,13 +649,20 @@ public class RubiksCubeModule : MonoBehaviour
 
                 if (isSolved(cubelets))
                 {
+                    yield return null;
                     yield return "solve";
                     goto perform;
                 }
             }
         }
 
+        if (rotations.Count > 0)
+            yield return null;
+
         perform:
+        if (rotations.Count > 20)
+            yield return "waiting music";
+
         foreach (var rot in rotations)
         {
             _queue.Enqueue(rot);

--- a/Assets/RubiksCubeModule.prefab
+++ b/Assets/RubiksCubeModule.prefab
@@ -5,14 +5,15 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 474250}
-  - 114: {fileID: 11429752}
-  - 114: {fileID: 11420650}
-  - 114: {fileID: 11489324}
-  - 114: {fileID: 11496072}
-  - 114: {fileID: 114000013280470726}
+  - component: {fileID: 474250}
+  - component: {fileID: 11429752}
+  - component: {fileID: 11420650}
+  - component: {fileID: 11489324}
+  - component: {fileID: 11496072}
+  - component: {fileID: 114000013280470726}
+  - component: {fileID: 114751797066452508}
   m_Layer: 0
   m_Name: RubiksCubeModule
   m_TagString: Untagged
@@ -25,12 +26,12 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 453294}
-  - 33: {fileID: 3359064}
-  - 23: {fileID: 2373828}
-  - 114: {fileID: 114000013758526718}
+  - component: {fileID: 453294}
+  - component: {fileID: 3359064}
+  - component: {fileID: 2373828}
+  - component: {fileID: 114000013758526718}
   m_Layer: 0
   m_Name: ComponentBackground
   m_TagString: Untagged
@@ -43,10 +44,10 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 413386}
-  - 114: {fileID: 11410154}
+  - component: {fileID: 413386}
+  - component: {fileID: 11410154}
   m_Layer: 0
   m_Name: StatusLight
   m_TagString: Untagged
@@ -59,11 +60,11 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 479804}
-  - 33: {fileID: 3398350}
-  - 114: {fileID: 11464240}
+  - component: {fileID: 479804}
+  - component: {fileID: 3398350}
+  - component: {fileID: 11464240}
   m_Layer: 11
   m_Name: ComponentHighlight
   m_TagString: Untagged
@@ -80,10 +81,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0.075167, y: 0.01986, z: 0.076057}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 474250}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &453294
 Transform:
   m_ObjectHideFlags: 1
@@ -93,10 +94,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 1, z: 0, w: -0.00000016292068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
   m_Children: []
   m_Father: {fileID: 474250}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
 --- !u!4 &474250
 Transform:
   m_ObjectHideFlags: 1
@@ -106,7 +107,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 453294}
   - {fileID: 479804}
@@ -114,6 +114,7 @@ Transform:
   - {fileID: 4000010759135422}
   m_Father: {fileID: 0}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &479804
 Transform:
   m_ObjectHideFlags: 1
@@ -123,10 +124,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 474250}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &2373828
 MeshRenderer:
   m_ObjectHideFlags: 1
@@ -141,7 +142,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 862f17cbb58f97947b039a62097cb349, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -149,12 +152,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &3359064
 MeshFilter:
@@ -288,12 +292,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000012003096180}
-  - 33: {fileID: 33000013667953764}
-  - 23: {fileID: 23000011455418576}
-  - 114: {fileID: 114000010166657616}
+  - component: {fileID: 4000012003096180}
+  - component: {fileID: 33000013667953764}
+  - component: {fileID: 23000011455418576}
+  - component: {fileID: 114000010166657616}
   m_Layer: 0
   m_Name: Cubelet (1, 2, 1)
   m_TagString: Untagged
@@ -306,12 +310,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000011092773186}
-  - 33: {fileID: 33000012629628448}
-  - 23: {fileID: 23000012685712688}
-  - 114: {fileID: 114000014274415444}
+  - component: {fileID: 4000011092773186}
+  - component: {fileID: 33000012629628448}
+  - component: {fileID: 23000012685712688}
+  - component: {fileID: 114000014274415444}
   m_Layer: 0
   m_Name: D sticker
   m_TagString: Untagged
@@ -324,11 +328,11 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000012087178338}
-  - 33: {fileID: 33000011167315026}
-  - 114: {fileID: 114000012131109376}
+  - component: {fileID: 4000012087178338}
+  - component: {fileID: 33000011167315026}
+  - component: {fileID: 114000012131109376}
   m_Layer: 0
   m_Name: Highlight
   m_TagString: Untagged
@@ -341,11 +345,11 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000012929691494}
-  - 33: {fileID: 33000011271677204}
-  - 114: {fileID: 114000012074052976}
+  - component: {fileID: 4000012929691494}
+  - component: {fileID: 33000011271677204}
+  - component: {fileID: 114000012074052976}
   m_Layer: 0
   m_Name: Highlight
   m_TagString: Untagged
@@ -358,11 +362,11 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000013878603692}
-  - 33: {fileID: 33000010668546160}
-  - 114: {fileID: 114000014195770672}
+  - component: {fileID: 4000013878603692}
+  - component: {fileID: 33000010668546160}
+  - component: {fileID: 114000014195770672}
   m_Layer: 0
   m_Name: Highlight
   m_TagString: Untagged
@@ -375,12 +379,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000013821416868}
-  - 33: {fileID: 33000010687707922}
-  - 23: {fileID: 23000013169679094}
-  - 114: {fileID: 114000012578464214}
+  - component: {fileID: 4000013821416868}
+  - component: {fileID: 33000010687707922}
+  - component: {fileID: 23000013169679094}
+  - component: {fileID: 114000012578464214}
   m_Layer: 0
   m_Name: U sticker
   m_TagString: Untagged
@@ -393,12 +397,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010640655676}
-  - 33: {fileID: 33000014241675688}
-  - 23: {fileID: 23000011249616576}
-  - 114: {fileID: 114000013273119624}
+  - component: {fileID: 4000010640655676}
+  - component: {fileID: 33000014241675688}
+  - component: {fileID: 23000011249616576}
+  - component: {fileID: 114000013273119624}
   m_Layer: 0
   m_Name: R sticker
   m_TagString: Untagged
@@ -411,13 +415,13 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010537944402}
-  - 114: {fileID: 114000012894041638}
-  - 33: {fileID: 33000013239272078}
-  - 23: {fileID: 23000013117716366}
-  - 114: {fileID: 114000011523073136}
+  - component: {fileID: 4000010537944402}
+  - component: {fileID: 114000012894041638}
+  - component: {fileID: 33000013239272078}
+  - component: {fileID: 23000013117716366}
+  - component: {fileID: 114000011523073136}
   m_Layer: 0
   m_Name: Pusher C
   m_TagString: Untagged
@@ -430,12 +434,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000013734051952}
-  - 33: {fileID: 33000010765743934}
-  - 23: {fileID: 23000010152233454}
-  - 114: {fileID: 114000013549453106}
+  - component: {fileID: 4000013734051952}
+  - component: {fileID: 33000010765743934}
+  - component: {fileID: 23000010152233454}
+  - component: {fileID: 114000013549453106}
   m_Layer: 0
   m_Name: U sticker
   m_TagString: Untagged
@@ -448,12 +452,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000013690353172}
-  - 33: {fileID: 33000013112514906}
-  - 23: {fileID: 23000012478539362}
-  - 114: {fileID: 114000013202626480}
+  - component: {fileID: 4000013690353172}
+  - component: {fileID: 33000013112514906}
+  - component: {fileID: 23000012478539362}
+  - component: {fileID: 114000013202626480}
   m_Layer: 0
   m_Name: D sticker
   m_TagString: Untagged
@@ -466,10 +470,10 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010402675894}
-  - 114: {fileID: 114000013702621918}
+  - component: {fileID: 4000010402675894}
+  - component: {fileID: 114000013702621918}
   m_Layer: 0
   m_Name: Reset
   m_TagString: Untagged
@@ -482,12 +486,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000011636893324}
-  - 33: {fileID: 33000013089909300}
-  - 23: {fileID: 23000012660143542}
-  - 114: {fileID: 114000013024257510}
+  - component: {fileID: 4000011636893324}
+  - component: {fileID: 33000013089909300}
+  - component: {fileID: 23000012660143542}
+  - component: {fileID: 114000013024257510}
   m_Layer: 0
   m_Name: D sticker
   m_TagString: Untagged
@@ -500,12 +504,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000012725870104}
-  - 33: {fileID: 33000011614533614}
-  - 23: {fileID: 23000011256254906}
-  - 114: {fileID: 114000011625013756}
+  - component: {fileID: 4000012725870104}
+  - component: {fileID: 33000011614533614}
+  - component: {fileID: 23000011256254906}
+  - component: {fileID: 114000011625013756}
   m_Layer: 0
   m_Name: L sticker
   m_TagString: Untagged
@@ -518,12 +522,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010242049322}
-  - 33: {fileID: 33000011070446104}
-  - 23: {fileID: 23000012346037064}
-  - 114: {fileID: 114000014265708096}
+  - component: {fileID: 4000010242049322}
+  - component: {fileID: 33000011070446104}
+  - component: {fileID: 23000012346037064}
+  - component: {fileID: 114000014265708096}
   m_Layer: 0
   m_Name: Cubelet (2, 2, 0)
   m_TagString: Untagged
@@ -536,12 +540,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010389589316}
-  - 33: {fileID: 33000010066025732}
-  - 23: {fileID: 23000012741528876}
-  - 114: {fileID: 114000012309115262}
+  - component: {fileID: 4000010389589316}
+  - component: {fileID: 33000010066025732}
+  - component: {fileID: 23000012741528876}
+  - component: {fileID: 114000012309115262}
   m_Layer: 0
   m_Name: L sticker
   m_TagString: Untagged
@@ -554,12 +558,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000013216064610}
-  - 33: {fileID: 33000012487720128}
-  - 23: {fileID: 23000010542011170}
-  - 114: {fileID: 114000013671003564}
+  - component: {fileID: 4000013216064610}
+  - component: {fileID: 33000012487720128}
+  - component: {fileID: 23000010542011170}
+  - component: {fileID: 114000013671003564}
   m_Layer: 0
   m_Name: Cubelet (0, 2, 0)
   m_TagString: Untagged
@@ -572,13 +576,13 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000014114397878}
-  - 114: {fileID: 114000010258482492}
-  - 33: {fileID: 33000013003179864}
-  - 23: {fileID: 23000011732654848}
-  - 114: {fileID: 114000012607622568}
+  - component: {fileID: 4000014114397878}
+  - component: {fileID: 114000010258482492}
+  - component: {fileID: 33000013003179864}
+  - component: {fileID: 23000011732654848}
+  - component: {fileID: 114000012607622568}
   m_Layer: 0
   m_Name: Pusher B
   m_TagString: Untagged
@@ -591,13 +595,13 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000013959298910}
-  - 114: {fileID: 114000011545397042}
-  - 33: {fileID: 33000011783870684}
-  - 23: {fileID: 23000011435996572}
-  - 114: {fileID: 114000011117741614}
+  - component: {fileID: 4000013959298910}
+  - component: {fileID: 114000011545397042}
+  - component: {fileID: 33000011783870684}
+  - component: {fileID: 23000011435996572}
+  - component: {fileID: 114000011117741614}
   m_Layer: 0
   m_Name: Pusher F
   m_TagString: Untagged
@@ -610,12 +614,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010790094764}
-  - 33: {fileID: 33000013549494876}
-  - 23: {fileID: 23000013349277184}
-  - 114: {fileID: 114000010121092224}
+  - component: {fileID: 4000010790094764}
+  - component: {fileID: 33000013549494876}
+  - component: {fileID: 23000013349277184}
+  - component: {fileID: 114000010121092224}
   m_Layer: 0
   m_Name: L sticker
   m_TagString: Untagged
@@ -628,12 +632,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000013913277266}
-  - 33: {fileID: 33000011849005728}
-  - 23: {fileID: 23000011095039286}
-  - 114: {fileID: 114000010001980724}
+  - component: {fileID: 4000013913277266}
+  - component: {fileID: 33000011849005728}
+  - component: {fileID: 23000011095039286}
+  - component: {fileID: 114000010001980724}
   m_Layer: 0
   m_Name: U sticker
   m_TagString: Untagged
@@ -646,12 +650,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010374669886}
-  - 33: {fileID: 33000010524260438}
-  - 23: {fileID: 23000011154186656}
-  - 114: {fileID: 114000013105536826}
+  - component: {fileID: 4000010374669886}
+  - component: {fileID: 33000010524260438}
+  - component: {fileID: 23000011154186656}
+  - component: {fileID: 114000013105536826}
   m_Layer: 0
   m_Name: B sticker
   m_TagString: Untagged
@@ -664,12 +668,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010840460470}
-  - 33: {fileID: 33000013389874672}
-  - 23: {fileID: 23000011174510226}
-  - 114: {fileID: 114000012621328266}
+  - component: {fileID: 4000010840460470}
+  - component: {fileID: 33000013389874672}
+  - component: {fileID: 23000011174510226}
+  - component: {fileID: 114000012621328266}
   m_Layer: 0
   m_Name: Cubelet (0, 2, 1)
   m_TagString: Untagged
@@ -682,12 +686,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010416199044}
-  - 33: {fileID: 33000010135961176}
-  - 23: {fileID: 23000014001124402}
-  - 114: {fileID: 114000012934292710}
+  - component: {fileID: 4000010416199044}
+  - component: {fileID: 33000010135961176}
+  - component: {fileID: 23000014001124402}
+  - component: {fileID: 114000012934292710}
   m_Layer: 0
   m_Name: U sticker
   m_TagString: Untagged
@@ -700,12 +704,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000013688063632}
-  - 33: {fileID: 33000013415778524}
-  - 23: {fileID: 23000011368981806}
-  - 114: {fileID: 114000011880664986}
+  - component: {fileID: 4000013688063632}
+  - component: {fileID: 33000013415778524}
+  - component: {fileID: 23000011368981806}
+  - component: {fileID: 114000011880664986}
   m_Layer: 0
   m_Name: Cubelet (1, 0, 2)
   m_TagString: Untagged
@@ -718,11 +722,11 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010179322970}
-  - 33: {fileID: 33000013789495480}
-  - 114: {fileID: 114000013616354212}
+  - component: {fileID: 4000010179322970}
+  - component: {fileID: 33000013789495480}
+  - component: {fileID: 114000013616354212}
   m_Layer: 0
   m_Name: Highlight
   m_TagString: Untagged
@@ -735,12 +739,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000011983782742}
-  - 33: {fileID: 33000010127944772}
-  - 23: {fileID: 23000010443646980}
-  - 114: {fileID: 114000011128759576}
+  - component: {fileID: 4000011983782742}
+  - component: {fileID: 33000010127944772}
+  - component: {fileID: 23000010443646980}
+  - component: {fileID: 114000011128759576}
   m_Layer: 0
   m_Name: B sticker
   m_TagString: Untagged
@@ -753,11 +757,11 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000011410605652}
-  - 33: {fileID: 33000010395926650}
-  - 114: {fileID: 114000010539260160}
+  - component: {fileID: 4000011410605652}
+  - component: {fileID: 33000010395926650}
+  - component: {fileID: 114000010539260160}
   m_Layer: 0
   m_Name: Highlight
   m_TagString: Untagged
@@ -770,11 +774,11 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000011860622312}
-  - 33: {fileID: 33000012418449912}
-  - 114: {fileID: 114000011302279836}
+  - component: {fileID: 4000011860622312}
+  - component: {fileID: 33000012418449912}
+  - component: {fileID: 114000011302279836}
   m_Layer: 0
   m_Name: Highlight
   m_TagString: Untagged
@@ -787,12 +791,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010260882894}
-  - 33: {fileID: 33000010156536852}
-  - 23: {fileID: 23000013014842766}
-  - 114: {fileID: 114000010859468820}
+  - component: {fileID: 4000010260882894}
+  - component: {fileID: 33000010156536852}
+  - component: {fileID: 23000013014842766}
+  - component: {fileID: 114000010859468820}
   m_Layer: 0
   m_Name: Cubelet (2, 0, 2)
   m_TagString: Untagged
@@ -805,12 +809,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000011999091050}
-  - 33: {fileID: 33000010767413582}
-  - 23: {fileID: 23000010182591898}
-  - 114: {fileID: 114000012197822318}
+  - component: {fileID: 4000011999091050}
+  - component: {fileID: 33000010767413582}
+  - component: {fileID: 23000010182591898}
+  - component: {fileID: 114000012197822318}
   m_Layer: 0
   m_Name: U sticker
   m_TagString: Untagged
@@ -823,12 +827,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010395518844}
-  - 33: {fileID: 33000010138989550}
-  - 23: {fileID: 23000011651382512}
-  - 114: {fileID: 114000010709011630}
+  - component: {fileID: 4000010395518844}
+  - component: {fileID: 33000010138989550}
+  - component: {fileID: 23000011651382512}
+  - component: {fileID: 114000010709011630}
   m_Layer: 0
   m_Name: Cubelet (2, 2, 2)
   m_TagString: Untagged
@@ -841,13 +845,13 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000012078948898}
-  - 114: {fileID: 114000011347030300}
-  - 33: {fileID: 33000012118310610}
-  - 23: {fileID: 23000011686379044}
-  - 114: {fileID: 114000011665247114}
+  - component: {fileID: 4000012078948898}
+  - component: {fileID: 114000011347030300}
+  - component: {fileID: 33000012118310610}
+  - component: {fileID: 23000011686379044}
+  - component: {fileID: 114000011665247114}
   m_Layer: 0
   m_Name: Pusher E
   m_TagString: Untagged
@@ -860,11 +864,11 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000012349687274}
-  - 33: {fileID: 33000013864201790}
-  - 114: {fileID: 114000013756073026}
+  - component: {fileID: 4000012349687274}
+  - component: {fileID: 33000013864201790}
+  - component: {fileID: 114000013756073026}
   m_Layer: 0
   m_Name: Highlight
   m_TagString: Untagged
@@ -877,12 +881,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010574272630}
-  - 33: {fileID: 33000010734260552}
-  - 23: {fileID: 23000012446562360}
-  - 114: {fileID: 114000012905931388}
+  - component: {fileID: 4000010574272630}
+  - component: {fileID: 33000010734260552}
+  - component: {fileID: 23000012446562360}
+  - component: {fileID: 114000012905931388}
   m_Layer: 0
   m_Name: Cubelet (1, 1, 0)
   m_TagString: Untagged
@@ -895,9 +899,9 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000012009388676}
+  - component: {fileID: 4000012009388676}
   m_Layer: 0
   m_Name: Pushers
   m_TagString: Untagged
@@ -910,13 +914,13 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010815577572}
-  - 114: {fileID: 114000010601931980}
-  - 33: {fileID: 33000012098671352}
-  - 23: {fileID: 23000013780545214}
-  - 114: {fileID: 114000010074976034}
+  - component: {fileID: 4000010815577572}
+  - component: {fileID: 114000010601931980}
+  - component: {fileID: 33000012098671352}
+  - component: {fileID: 23000013780545214}
+  - component: {fileID: 114000010074976034}
   m_Layer: 0
   m_Name: Pusher H
   m_TagString: Untagged
@@ -929,12 +933,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000012931313718}
-  - 33: {fileID: 33000013860670992}
-  - 23: {fileID: 23000010663999318}
-  - 114: {fileID: 114000010024255354}
+  - component: {fileID: 4000012931313718}
+  - component: {fileID: 33000013860670992}
+  - component: {fileID: 23000010663999318}
+  - component: {fileID: 114000010024255354}
   m_Layer: 0
   m_Name: B sticker
   m_TagString: Untagged
@@ -947,12 +951,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000012151036550}
-  - 33: {fileID: 33000014241692990}
-  - 23: {fileID: 23000013575804314}
-  - 114: {fileID: 114000014276739034}
+  - component: {fileID: 4000012151036550}
+  - component: {fileID: 33000014241692990}
+  - component: {fileID: 23000013575804314}
+  - component: {fileID: 114000014276739034}
   m_Layer: 0
   m_Name: D sticker
   m_TagString: Untagged
@@ -965,12 +969,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000011343104580}
-  - 33: {fileID: 33000010104595912}
-  - 23: {fileID: 23000013987257600}
-  - 114: {fileID: 114000012846465170}
+  - component: {fileID: 4000011343104580}
+  - component: {fileID: 33000010104595912}
+  - component: {fileID: 23000013987257600}
+  - component: {fileID: 114000012846465170}
   m_Layer: 0
   m_Name: R sticker
   m_TagString: Untagged
@@ -983,12 +987,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000013261128892}
-  - 33: {fileID: 33000011304539316}
-  - 23: {fileID: 23000012754193118}
-  - 114: {fileID: 114000011327548086}
+  - component: {fileID: 4000013261128892}
+  - component: {fileID: 33000011304539316}
+  - component: {fileID: 23000012754193118}
+  - component: {fileID: 114000011327548086}
   m_Layer: 0
   m_Name: B sticker
   m_TagString: Untagged
@@ -1001,12 +1005,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010353816684}
-  - 33: {fileID: 33000013923558844}
-  - 23: {fileID: 23000013945920958}
-  - 114: {fileID: 114000011003675462}
+  - component: {fileID: 4000010353816684}
+  - component: {fileID: 33000013923558844}
+  - component: {fileID: 23000013945920958}
+  - component: {fileID: 114000011003675462}
   m_Layer: 0
   m_Name: Cubelet (2, 0, 0)
   m_TagString: Untagged
@@ -1019,12 +1023,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010018887462}
-  - 33: {fileID: 33000014258162206}
-  - 23: {fileID: 23000010497134790}
-  - 114: {fileID: 114000012581250392}
+  - component: {fileID: 4000010018887462}
+  - component: {fileID: 33000014258162206}
+  - component: {fileID: 23000010497134790}
+  - component: {fileID: 114000012581250392}
   m_Layer: 0
   m_Name: R sticker
   m_TagString: Untagged
@@ -1037,12 +1041,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000012498516904}
-  - 33: {fileID: 33000011369311456}
-  - 23: {fileID: 23000011649196236}
-  - 114: {fileID: 114000012379087516}
+  - component: {fileID: 4000012498516904}
+  - component: {fileID: 33000011369311456}
+  - component: {fileID: 23000011649196236}
+  - component: {fileID: 114000012379087516}
   m_Layer: 0
   m_Name: L sticker
   m_TagString: Untagged
@@ -1055,12 +1059,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000012700339238}
-  - 33: {fileID: 33000012931284462}
-  - 23: {fileID: 23000010416953104}
-  - 114: {fileID: 114000013230428002}
+  - component: {fileID: 4000012700339238}
+  - component: {fileID: 33000012931284462}
+  - component: {fileID: 23000010416953104}
+  - component: {fileID: 114000013230428002}
   m_Layer: 0
   m_Name: Cubelet (1, 2, 0)
   m_TagString: Untagged
@@ -1073,12 +1077,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000011203728406}
-  - 33: {fileID: 33000010370761012}
-  - 23: {fileID: 23000011022109152}
-  - 114: {fileID: 114000013025865338}
+  - component: {fileID: 4000011203728406}
+  - component: {fileID: 33000010370761012}
+  - component: {fileID: 23000011022109152}
+  - component: {fileID: 114000013025865338}
   m_Layer: 0
   m_Name: L sticker
   m_TagString: Untagged
@@ -1091,12 +1095,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010389731036}
-  - 33: {fileID: 33000013322002668}
-  - 23: {fileID: 23000010837334206}
-  - 114: {fileID: 114000010026053772}
+  - component: {fileID: 4000010389731036}
+  - component: {fileID: 33000013322002668}
+  - component: {fileID: 23000010837334206}
+  - component: {fileID: 114000010026053772}
   m_Layer: 0
   m_Name: Cubelet (0, 1, 0)
   m_TagString: Untagged
@@ -1109,13 +1113,13 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000013430938988}
-  - 114: {fileID: 114000013853703020}
-  - 33: {fileID: 33000011884514334}
-  - 23: {fileID: 23000011061961808}
-  - 114: {fileID: 114000011619659092}
+  - component: {fileID: 4000013430938988}
+  - component: {fileID: 114000013853703020}
+  - component: {fileID: 33000011884514334}
+  - component: {fileID: 23000011061961808}
+  - component: {fileID: 114000011619659092}
   m_Layer: 0
   m_Name: Pusher K
   m_TagString: Untagged
@@ -1128,12 +1132,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000013861139206}
-  - 33: {fileID: 33000014274032550}
-  - 23: {fileID: 23000012461839264}
-  - 114: {fileID: 114000013525715728}
+  - component: {fileID: 4000013861139206}
+  - component: {fileID: 33000014274032550}
+  - component: {fileID: 23000012461839264}
+  - component: {fileID: 114000013525715728}
   m_Layer: 0
   m_Name: D sticker
   m_TagString: Untagged
@@ -1146,9 +1150,9 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000011757126956}
+  - component: {fileID: 4000011757126956}
   m_Layer: 0
   m_Name: OnAxis
   m_TagString: Untagged
@@ -1161,13 +1165,13 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000014222402742}
-  - 114: {fileID: 114000012451017722}
-  - 33: {fileID: 33000013216389518}
-  - 23: {fileID: 23000013072819516}
-  - 114: {fileID: 114000011220955510}
+  - component: {fileID: 4000014222402742}
+  - component: {fileID: 114000012451017722}
+  - component: {fileID: 33000013216389518}
+  - component: {fileID: 23000013072819516}
+  - component: {fileID: 114000011220955510}
   m_Layer: 0
   m_Name: Pusher A
   m_TagString: Untagged
@@ -1180,11 +1184,11 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000011712990266}
-  - 114: {fileID: 114000011657232864}
-  - 33: {fileID: 33000011387497770}
+  - component: {fileID: 4000011712990266}
+  - component: {fileID: 114000011657232864}
+  - component: {fileID: 33000011387497770}
   m_Layer: 0
   m_Name: Highlight
   m_TagString: Untagged
@@ -1197,12 +1201,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000012873274248}
-  - 33: {fileID: 33000013123963418}
-  - 23: {fileID: 23000013655333500}
-  - 114: {fileID: 114000014037536836}
+  - component: {fileID: 4000012873274248}
+  - component: {fileID: 33000013123963418}
+  - component: {fileID: 23000013655333500}
+  - component: {fileID: 114000014037536836}
   m_Layer: 0
   m_Name: D sticker
   m_TagString: Untagged
@@ -1215,9 +1219,9 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000013849328254}
+  - component: {fileID: 4000013849328254}
   m_Layer: 0
   m_Name: OffAxis
   m_TagString: Untagged
@@ -1230,12 +1234,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000013518515276}
-  - 23: {fileID: 23000011439698592}
-  - 33: {fileID: 33000012018288688}
-  - 114: {fileID: 114000013021780600}
+  - component: {fileID: 4000013518515276}
+  - component: {fileID: 23000011439698592}
+  - component: {fileID: 33000012018288688}
+  - component: {fileID: 114000013021780600}
   m_Layer: 0
   m_Name: ResetText
   m_TagString: Untagged
@@ -1248,12 +1252,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000014054861136}
-  - 33: {fileID: 33000010301228784}
-  - 23: {fileID: 23000011104732210}
-  - 114: {fileID: 114000012731962058}
+  - component: {fileID: 4000014054861136}
+  - component: {fileID: 33000010301228784}
+  - component: {fileID: 23000011104732210}
+  - component: {fileID: 114000012731962058}
   m_Layer: 0
   m_Name: Cubelet (1, 0, 1)
   m_TagString: Untagged
@@ -1266,12 +1270,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000012777973900}
-  - 33: {fileID: 33000010589265290}
-  - 23: {fileID: 23000011007433384}
-  - 114: {fileID: 114000011542365774}
+  - component: {fileID: 4000012777973900}
+  - component: {fileID: 33000010589265290}
+  - component: {fileID: 23000011007433384}
+  - component: {fileID: 114000011542365774}
   m_Layer: 0
   m_Name: B sticker
   m_TagString: Untagged
@@ -1284,12 +1288,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000013558227822}
-  - 33: {fileID: 33000014233064964}
-  - 23: {fileID: 23000011785937136}
-  - 114: {fileID: 114000013372887478}
+  - component: {fileID: 4000013558227822}
+  - component: {fileID: 33000014233064964}
+  - component: {fileID: 23000011785937136}
+  - component: {fileID: 114000013372887478}
   m_Layer: 0
   m_Name: Cubelet (2, 1, 0)
   m_TagString: Untagged
@@ -1302,12 +1306,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000013248361220}
-  - 33: {fileID: 33000012584405934}
-  - 23: {fileID: 23000010986005014}
-  - 114: {fileID: 114000013787303728}
+  - component: {fileID: 4000013248361220}
+  - component: {fileID: 33000012584405934}
+  - component: {fileID: 23000010986005014}
+  - component: {fileID: 114000013787303728}
   m_Layer: 0
   m_Name: B sticker
   m_TagString: Untagged
@@ -1320,12 +1324,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000014143118706}
-  - 33: {fileID: 33000014198924830}
-  - 23: {fileID: 23000011029076442}
-  - 114: {fileID: 114000012801131550}
+  - component: {fileID: 4000014143118706}
+  - component: {fileID: 33000014198924830}
+  - component: {fileID: 23000011029076442}
+  - component: {fileID: 114000012801131550}
   m_Layer: 0
   m_Name: R sticker
   m_TagString: Untagged
@@ -1338,12 +1342,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000012168034430}
-  - 33: {fileID: 33000012406744758}
-  - 23: {fileID: 23000010525892768}
-  - 114: {fileID: 114000013881018454}
+  - component: {fileID: 4000012168034430}
+  - component: {fileID: 33000012406744758}
+  - component: {fileID: 23000010525892768}
+  - component: {fileID: 114000013881018454}
   m_Layer: 0
   m_Name: Cubelet (1, 1, 2)
   m_TagString: Untagged
@@ -1356,12 +1360,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000014084031438}
-  - 33: {fileID: 33000013719605658}
-  - 23: {fileID: 23000011228606762}
-  - 114: {fileID: 114000013119985132}
+  - component: {fileID: 4000014084031438}
+  - component: {fileID: 33000013719605658}
+  - component: {fileID: 23000011228606762}
+  - component: {fileID: 114000013119985132}
   m_Layer: 0
   m_Name: D sticker
   m_TagString: Untagged
@@ -1374,12 +1378,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010605959690}
-  - 33: {fileID: 33000011245775582}
-  - 23: {fileID: 23000012476740840}
-  - 114: {fileID: 114000013098923248}
+  - component: {fileID: 4000010605959690}
+  - component: {fileID: 33000011245775582}
+  - component: {fileID: 23000012476740840}
+  - component: {fileID: 114000013098923248}
   m_Layer: 0
   m_Name: F sticker
   m_TagString: Untagged
@@ -1392,12 +1396,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000011353769578}
-  - 33: {fileID: 33000012120028540}
-  - 23: {fileID: 23000010670157426}
-  - 114: {fileID: 114000013436180634}
+  - component: {fileID: 4000011353769578}
+  - component: {fileID: 33000012120028540}
+  - component: {fileID: 23000010670157426}
+  - component: {fileID: 114000013436180634}
   m_Layer: 0
   m_Name: F sticker
   m_TagString: Untagged
@@ -1410,12 +1414,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000011760460316}
-  - 33: {fileID: 33000010255825500}
-  - 23: {fileID: 23000011698701706}
-  - 114: {fileID: 114000010215888086}
+  - component: {fileID: 4000011760460316}
+  - component: {fileID: 33000010255825500}
+  - component: {fileID: 23000011698701706}
+  - component: {fileID: 114000010215888086}
   m_Layer: 0
   m_Name: R sticker
   m_TagString: Untagged
@@ -1428,12 +1432,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000011769768434}
-  - 33: {fileID: 33000013810414240}
-  - 23: {fileID: 23000010423174614}
-  - 114: {fileID: 114000011000289754}
+  - component: {fileID: 4000011769768434}
+  - component: {fileID: 33000013810414240}
+  - component: {fileID: 23000010423174614}
+  - component: {fileID: 114000011000289754}
   m_Layer: 0
   m_Name: U sticker
   m_TagString: Untagged
@@ -1446,12 +1450,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010812395584}
-  - 33: {fileID: 33000011220339968}
-  - 23: {fileID: 23000012954480808}
-  - 114: {fileID: 114000013226895134}
+  - component: {fileID: 4000010812395584}
+  - component: {fileID: 33000011220339968}
+  - component: {fileID: 23000012954480808}
+  - component: {fileID: 114000013226895134}
   m_Layer: 0
   m_Name: L sticker
   m_TagString: Untagged
@@ -1464,12 +1468,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000011067675276}
-  - 33: {fileID: 33000011039942982}
-  - 23: {fileID: 23000012781332370}
-  - 114: {fileID: 114000013432946398}
+  - component: {fileID: 4000011067675276}
+  - component: {fileID: 33000011039942982}
+  - component: {fileID: 23000012781332370}
+  - component: {fileID: 114000013432946398}
   m_Layer: 0
   m_Name: Cubelet (0, 0, 2)
   m_TagString: Untagged
@@ -1482,12 +1486,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000013641552310}
-  - 33: {fileID: 33000012644261890}
-  - 23: {fileID: 23000012389412998}
-  - 114: {fileID: 114000011319373372}
+  - component: {fileID: 4000013641552310}
+  - component: {fileID: 33000012644261890}
+  - component: {fileID: 23000012389412998}
+  - component: {fileID: 114000011319373372}
   m_Layer: 0
   m_Name: F sticker
   m_TagString: Untagged
@@ -1500,12 +1504,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000012588663612}
-  - 33: {fileID: 33000010299902628}
-  - 23: {fileID: 23000013864311222}
-  - 114: {fileID: 114000013524815208}
+  - component: {fileID: 4000012588663612}
+  - component: {fileID: 33000010299902628}
+  - component: {fileID: 23000013864311222}
+  - component: {fileID: 114000013524815208}
   m_Layer: 0
   m_Name: R sticker
   m_TagString: Untagged
@@ -1518,12 +1522,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000011059494508}
-  - 33: {fileID: 33000010291270820}
-  - 23: {fileID: 23000011219514246}
-  - 114: {fileID: 114000011535151918}
+  - component: {fileID: 4000011059494508}
+  - component: {fileID: 33000010291270820}
+  - component: {fileID: 23000011219514246}
+  - component: {fileID: 114000011535151918}
   m_Layer: 0
   m_Name: L sticker
   m_TagString: Untagged
@@ -1536,12 +1540,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000012458002360}
-  - 33: {fileID: 33000011293488708}
-  - 23: {fileID: 23000010669993228}
-  - 114: {fileID: 114000010517800352}
+  - component: {fileID: 4000012458002360}
+  - component: {fileID: 33000011293488708}
+  - component: {fileID: 23000010669993228}
+  - component: {fileID: 114000010517800352}
   m_Layer: 0
   m_Name: D sticker
   m_TagString: Untagged
@@ -1554,11 +1558,11 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010748016836}
-  - 33: {fileID: 33000012534539652}
-  - 114: {fileID: 114000012662973480}
+  - component: {fileID: 4000010748016836}
+  - component: {fileID: 33000012534539652}
+  - component: {fileID: 114000012662973480}
   m_Layer: 0
   m_Name: Highlight
   m_TagString: Untagged
@@ -1571,12 +1575,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000013885329996}
-  - 33: {fileID: 33000011727232068}
-  - 23: {fileID: 23000012400344774}
-  - 114: {fileID: 114000010083045650}
+  - component: {fileID: 4000013885329996}
+  - component: {fileID: 33000011727232068}
+  - component: {fileID: 23000012400344774}
+  - component: {fileID: 114000010083045650}
   m_Layer: 0
   m_Name: B sticker
   m_TagString: Untagged
@@ -1589,12 +1593,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010747608656}
-  - 33: {fileID: 33000010793558440}
-  - 23: {fileID: 23000013580629118}
-  - 114: {fileID: 114000010902991558}
+  - component: {fileID: 4000010747608656}
+  - component: {fileID: 33000010793558440}
+  - component: {fileID: 23000013580629118}
+  - component: {fileID: 114000010902991558}
   m_Layer: 0
   m_Name: Cubelet (2, 0, 1)
   m_TagString: Untagged
@@ -1607,13 +1611,13 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000011024939302}
-  - 114: {fileID: 114000013251973222}
-  - 33: {fileID: 33000010855952860}
-  - 23: {fileID: 23000013015702288}
-  - 114: {fileID: 114000010712444656}
+  - component: {fileID: 4000011024939302}
+  - component: {fileID: 114000013251973222}
+  - component: {fileID: 33000010855952860}
+  - component: {fileID: 23000013015702288}
+  - component: {fileID: 114000010712444656}
   m_Layer: 0
   m_Name: Pusher G
   m_TagString: Untagged
@@ -1626,12 +1630,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000012006565106}
-  - 33: {fileID: 33000010109690374}
-  - 23: {fileID: 23000012431294952}
-  - 114: {fileID: 114000012066220990}
+  - component: {fileID: 4000012006565106}
+  - component: {fileID: 33000010109690374}
+  - component: {fileID: 23000012431294952}
+  - component: {fileID: 114000012066220990}
   m_Layer: 0
   m_Name: Cubelet (2, 2, 1)
   m_TagString: Untagged
@@ -1644,11 +1648,11 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000012994578320}
-  - 33: {fileID: 33000013453369918}
-  - 114: {fileID: 114000012052875150}
+  - component: {fileID: 4000012994578320}
+  - component: {fileID: 33000013453369918}
+  - component: {fileID: 114000012052875150}
   m_Layer: 0
   m_Name: Highlight
   m_TagString: Untagged
@@ -1661,13 +1665,13 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010214419708}
-  - 114: {fileID: 114000010918390920}
-  - 33: {fileID: 33000011562024412}
-  - 23: {fileID: 23000010585640078}
-  - 114: {fileID: 114000011221749604}
+  - component: {fileID: 4000010214419708}
+  - component: {fileID: 114000010918390920}
+  - component: {fileID: 33000011562024412}
+  - component: {fileID: 23000010585640078}
+  - component: {fileID: 114000011221749604}
   m_Layer: 0
   m_Name: Pusher I
   m_TagString: Untagged
@@ -1680,12 +1684,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000011050292958}
-  - 33: {fileID: 33000011398511572}
-  - 23: {fileID: 23000010332892714}
-  - 114: {fileID: 114000013375752604}
+  - component: {fileID: 4000011050292958}
+  - component: {fileID: 33000011398511572}
+  - component: {fileID: 23000010332892714}
+  - component: {fileID: 114000013375752604}
   m_Layer: 0
   m_Name: R sticker
   m_TagString: Untagged
@@ -1698,12 +1702,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000011542102458}
-  - 33: {fileID: 33000012964007972}
-  - 23: {fileID: 23000013589934874}
-  - 114: {fileID: 114000012302418976}
+  - component: {fileID: 4000011542102458}
+  - component: {fileID: 33000012964007972}
+  - component: {fileID: 23000013589934874}
+  - component: {fileID: 114000012302418976}
   m_Layer: 0
   m_Name: Cubelet (2, 1, 1)
   m_TagString: Untagged
@@ -1716,12 +1720,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010933029818}
-  - 33: {fileID: 33000013068259972}
-  - 23: {fileID: 23000013107182616}
-  - 114: {fileID: 114000013313338118}
+  - component: {fileID: 4000010933029818}
+  - component: {fileID: 33000013068259972}
+  - component: {fileID: 23000013107182616}
+  - component: {fileID: 114000013313338118}
   m_Layer: 0
   m_Name: L sticker
   m_TagString: Untagged
@@ -1734,12 +1738,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000012441471684}
-  - 33: {fileID: 33000013456586986}
-  - 23: {fileID: 23000010799551746}
-  - 114: {fileID: 114000011016128120}
+  - component: {fileID: 4000012441471684}
+  - component: {fileID: 33000013456586986}
+  - component: {fileID: 23000010799551746}
+  - component: {fileID: 114000011016128120}
   m_Layer: 0
   m_Name: Cubelet (0, 0, 0)
   m_TagString: Untagged
@@ -1752,12 +1756,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000013748835054}
-  - 33: {fileID: 33000012701844474}
-  - 23: {fileID: 23000012330836776}
-  - 114: {fileID: 114000012900031304}
+  - component: {fileID: 4000013748835054}
+  - component: {fileID: 33000012701844474}
+  - component: {fileID: 23000012330836776}
+  - component: {fileID: 114000012900031304}
   m_Layer: 0
   m_Name: F sticker
   m_TagString: Untagged
@@ -1770,13 +1774,13 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010357744150}
-  - 114: {fileID: 114000011021043264}
-  - 33: {fileID: 33000012044518662}
-  - 23: {fileID: 23000012481975348}
-  - 114: {fileID: 114000013042370994}
+  - component: {fileID: 4000010357744150}
+  - component: {fileID: 114000011021043264}
+  - component: {fileID: 33000012044518662}
+  - component: {fileID: 23000012481975348}
+  - component: {fileID: 114000013042370994}
   m_Layer: 0
   m_Name: Pusher D
   m_TagString: Untagged
@@ -1789,12 +1793,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010723032348}
-  - 33: {fileID: 33000013951104402}
-  - 23: {fileID: 23000012176563066}
-  - 114: {fileID: 114000011140267492}
+  - component: {fileID: 4000010723032348}
+  - component: {fileID: 33000013951104402}
+  - component: {fileID: 23000012176563066}
+  - component: {fileID: 114000011140267492}
   m_Layer: 0
   m_Name: D sticker
   m_TagString: Untagged
@@ -1807,12 +1811,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000011108317162}
-  - 33: {fileID: 33000013942196078}
-  - 23: {fileID: 23000011727584160}
-  - 114: {fileID: 114000012965081192}
+  - component: {fileID: 4000011108317162}
+  - component: {fileID: 33000013942196078}
+  - component: {fileID: 23000011727584160}
+  - component: {fileID: 114000012965081192}
   m_Layer: 0
   m_Name: Cubelet (0, 1, 2)
   m_TagString: Untagged
@@ -1825,12 +1829,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000013738885272}
-  - 33: {fileID: 33000011452876632}
-  - 23: {fileID: 23000010507217582}
-  - 114: {fileID: 114000013807659932}
+  - component: {fileID: 4000013738885272}
+  - component: {fileID: 33000011452876632}
+  - component: {fileID: 23000010507217582}
+  - component: {fileID: 114000013807659932}
   m_Layer: 0
   m_Name: L sticker
   m_TagString: Untagged
@@ -1843,12 +1847,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010985990576}
-  - 33: {fileID: 33000011700442776}
-  - 23: {fileID: 23000012763507068}
-  - 114: {fileID: 114000012122908768}
+  - component: {fileID: 4000010985990576}
+  - component: {fileID: 33000011700442776}
+  - component: {fileID: 23000012763507068}
+  - component: {fileID: 114000012122908768}
   m_Layer: 0
   m_Name: U sticker
   m_TagString: Untagged
@@ -1861,12 +1865,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010766034876}
-  - 33: {fileID: 33000010111186772}
-  - 23: {fileID: 23000012717694236}
-  - 114: {fileID: 114000012589707222}
+  - component: {fileID: 4000010766034876}
+  - component: {fileID: 33000010111186772}
+  - component: {fileID: 23000012717694236}
+  - component: {fileID: 114000012589707222}
   m_Layer: 0
   m_Name: R sticker
   m_TagString: Untagged
@@ -1879,12 +1883,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000014088704204}
-  - 33: {fileID: 33000013317726750}
-  - 23: {fileID: 23000012658364258}
-  - 114: {fileID: 114000011443924684}
+  - component: {fileID: 4000014088704204}
+  - component: {fileID: 33000013317726750}
+  - component: {fileID: 23000012658364258}
+  - component: {fileID: 114000011443924684}
   m_Layer: 0
   m_Name: B sticker
   m_TagString: Untagged
@@ -1897,12 +1901,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000011236259716}
-  - 33: {fileID: 33000011204500552}
-  - 23: {fileID: 23000010938276878}
-  - 114: {fileID: 114000010767075796}
+  - component: {fileID: 4000011236259716}
+  - component: {fileID: 33000011204500552}
+  - component: {fileID: 23000010938276878}
+  - component: {fileID: 114000010767075796}
   m_Layer: 0
   m_Name: Cubelet (0, 2, 2)
   m_TagString: Untagged
@@ -1915,12 +1919,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000014126019588}
-  - 33: {fileID: 33000010044614594}
-  - 23: {fileID: 23000011091832898}
-  - 114: {fileID: 114000011807171840}
+  - component: {fileID: 4000014126019588}
+  - component: {fileID: 33000010044614594}
+  - component: {fileID: 23000011091832898}
+  - component: {fileID: 114000011807171840}
   m_Layer: 0
   m_Name: B sticker
   m_TagString: Untagged
@@ -1933,12 +1937,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000013230975600}
-  - 33: {fileID: 33000010402552174}
-  - 23: {fileID: 23000013890717450}
-  - 114: {fileID: 114000013145540904}
+  - component: {fileID: 4000013230975600}
+  - component: {fileID: 33000010402552174}
+  - component: {fileID: 23000013890717450}
+  - component: {fileID: 114000013145540904}
   m_Layer: 0
   m_Name: Cubelet (1, 2, 2)
   m_TagString: Untagged
@@ -1951,12 +1955,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010427142062}
-  - 33: {fileID: 33000010864954570}
-  - 23: {fileID: 23000011273551432}
-  - 114: {fileID: 114000012342479200}
+  - component: {fileID: 4000010427142062}
+  - component: {fileID: 33000010864954570}
+  - component: {fileID: 23000011273551432}
+  - component: {fileID: 114000012342479200}
   m_Layer: 0
   m_Name: F sticker
   m_TagString: Untagged
@@ -1969,12 +1973,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000013453137090}
-  - 33: {fileID: 33000013044498918}
-  - 23: {fileID: 23000012475012704}
-  - 114: {fileID: 114000010366487658}
+  - component: {fileID: 4000013453137090}
+  - component: {fileID: 33000013044498918}
+  - component: {fileID: 23000012475012704}
+  - component: {fileID: 114000010366487658}
   m_Layer: 0
   m_Name: F sticker
   m_TagString: Untagged
@@ -1987,12 +1991,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000013710424504}
-  - 33: {fileID: 33000010296484090}
-  - 23: {fileID: 23000010677518874}
-  - 114: {fileID: 114000011818557932}
+  - component: {fileID: 4000013710424504}
+  - component: {fileID: 33000010296484090}
+  - component: {fileID: 23000010677518874}
+  - component: {fileID: 114000011818557932}
   m_Layer: 0
   m_Name: F sticker
   m_TagString: Untagged
@@ -2005,12 +2009,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000011012383888}
-  - 33: {fileID: 33000012290027874}
-  - 23: {fileID: 23000013293873462}
-  - 114: {fileID: 114000013254266418}
+  - component: {fileID: 4000011012383888}
+  - component: {fileID: 33000012290027874}
+  - component: {fileID: 23000013293873462}
+  - component: {fileID: 114000013254266418}
   m_Layer: 0
   m_Name: U sticker
   m_TagString: Untagged
@@ -2023,12 +2027,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000011949948730}
-  - 33: {fileID: 33000012147209268}
-  - 23: {fileID: 23000010959930140}
-  - 114: {fileID: 114000010517635616}
+  - component: {fileID: 4000011949948730}
+  - component: {fileID: 33000012147209268}
+  - component: {fileID: 23000010959930140}
+  - component: {fileID: 114000010517635616}
   m_Layer: 0
   m_Name: Cubelet (0, 0, 1)
   m_TagString: Untagged
@@ -2041,9 +2045,9 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010759135422}
+  - component: {fileID: 4000010759135422}
   m_Layer: 0
   m_Name: Cube
   m_TagString: Untagged
@@ -2056,13 +2060,13 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010327542202}
-  - 114: {fileID: 114000011294610724}
-  - 33: {fileID: 33000011895315370}
-  - 23: {fileID: 23000011383030498}
-  - 114: {fileID: 114000012848097080}
+  - component: {fileID: 4000010327542202}
+  - component: {fileID: 114000011294610724}
+  - component: {fileID: 33000011895315370}
+  - component: {fileID: 23000011383030498}
+  - component: {fileID: 114000012848097080}
   m_Layer: 0
   m_Name: Pusher J
   m_TagString: Untagged
@@ -2075,12 +2079,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000012050999054}
-  - 33: {fileID: 33000011906300410}
-  - 23: {fileID: 23000014269021472}
-  - 114: {fileID: 114000012860440212}
+  - component: {fileID: 4000012050999054}
+  - component: {fileID: 33000011906300410}
+  - component: {fileID: 23000014269021472}
+  - component: {fileID: 114000012860440212}
   m_Layer: 0
   m_Name: Cubelet (0, 1, 1)
   m_TagString: Untagged
@@ -2093,12 +2097,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000011619460948}
-  - 33: {fileID: 33000010956889546}
-  - 23: {fileID: 23000014277856836}
-  - 114: {fileID: 114000010064523084}
+  - component: {fileID: 4000011619460948}
+  - component: {fileID: 33000010956889546}
+  - component: {fileID: 23000014277856836}
+  - component: {fileID: 114000010064523084}
   m_Layer: 0
   m_Name: Cubelet (1, 0, 0)
   m_TagString: Untagged
@@ -2111,12 +2115,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000012664039266}
-  - 33: {fileID: 33000010358373652}
-  - 23: {fileID: 23000013421017940}
-  - 114: {fileID: 114000012338419170}
+  - component: {fileID: 4000012664039266}
+  - component: {fileID: 33000010358373652}
+  - component: {fileID: 23000013421017940}
+  - component: {fileID: 114000012338419170}
   m_Layer: 0
   m_Name: F sticker
   m_TagString: Untagged
@@ -2129,11 +2133,11 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000013349972066}
-  - 33: {fileID: 33000010277226408}
-  - 114: {fileID: 114000012887816280}
+  - component: {fileID: 4000013349972066}
+  - component: {fileID: 33000010277226408}
+  - component: {fileID: 114000012887816280}
   m_Layer: 0
   m_Name: Highlight
   m_TagString: Untagged
@@ -2146,11 +2150,11 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000012222960206}
-  - 33: {fileID: 33000011021689072}
-  - 114: {fileID: 114000013554236278}
+  - component: {fileID: 4000012222960206}
+  - component: {fileID: 33000011021689072}
+  - component: {fileID: 114000013554236278}
   m_Layer: 0
   m_Name: Highlight
   m_TagString: Untagged
@@ -2163,12 +2167,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010898279106}
-  - 33: {fileID: 33000010189242786}
-  - 23: {fileID: 23000011635541786}
-  - 114: {fileID: 114000014059327716}
+  - component: {fileID: 4000010898279106}
+  - component: {fileID: 33000010189242786}
+  - component: {fileID: 23000011635541786}
+  - component: {fileID: 114000014059327716}
   m_Layer: 0
   m_Name: F sticker
   m_TagString: Untagged
@@ -2181,12 +2185,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000013298190686}
-  - 33: {fileID: 33000011359486092}
-  - 23: {fileID: 23000012253316974}
-  - 114: {fileID: 114000011566905090}
+  - component: {fileID: 4000013298190686}
+  - component: {fileID: 33000011359486092}
+  - component: {fileID: 23000012253316974}
+  - component: {fileID: 114000011566905090}
   m_Layer: 0
   m_Name: R sticker
   m_TagString: Untagged
@@ -2199,11 +2203,11 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000013272657826}
-  - 33: {fileID: 33000014220135984}
-  - 114: {fileID: 114000010447618110}
+  - component: {fileID: 4000013272657826}
+  - component: {fileID: 33000014220135984}
+  - component: {fileID: 114000010447618110}
   m_Layer: 0
   m_Name: Highlight
   m_TagString: Untagged
@@ -2216,13 +2220,13 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000014289868594}
-  - 114: {fileID: 114000012485986634}
-  - 33: {fileID: 33000011655502112}
-  - 23: {fileID: 23000013958927208}
-  - 114: {fileID: 114000010933374520}
+  - component: {fileID: 4000014289868594}
+  - component: {fileID: 114000012485986634}
+  - component: {fileID: 33000011655502112}
+  - component: {fileID: 23000013958927208}
+  - component: {fileID: 114000010933374520}
   m_Layer: 0
   m_Name: Pusher L
   m_TagString: Untagged
@@ -2235,12 +2239,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000010656965664}
-  - 33: {fileID: 33000012244533734}
-  - 23: {fileID: 23000010019435540}
-  - 114: {fileID: 114000011766231550}
+  - component: {fileID: 4000010656965664}
+  - component: {fileID: 33000012244533734}
+  - component: {fileID: 23000010019435540}
+  - component: {fileID: 114000011766231550}
   m_Layer: 0
   m_Name: U sticker
   m_TagString: Untagged
@@ -2253,12 +2257,12 @@ GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 4000011783535876}
-  - 33: {fileID: 33000010560134450}
-  - 23: {fileID: 23000014233347352}
-  - 114: {fileID: 114000012213003312}
+  - component: {fileID: 4000011783535876}
+  - component: {fileID: 33000010560134450}
+  - component: {fileID: 23000014233347352}
+  - component: {fileID: 114000012213003312}
   m_Layer: 0
   m_Name: Cubelet (2, 1, 2)
   m_TagString: Untagged
@@ -2275,10 +2279,10 @@ Transform:
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000013558227822}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000010179322970
 Transform:
   m_ObjectHideFlags: 1
@@ -2288,10 +2292,10 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: 4.4408905e-16, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
   m_Children: []
   m_Father: {fileID: 4000011024939302}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
 --- !u!4 &4000010214419708
 Transform:
   m_ObjectHideFlags: 1
@@ -2301,11 +2305,11 @@ Transform:
   m_LocalRotation: {x: 1, y: 0, z: 0, w: 0}
   m_LocalPosition: {x: 2, y: 3.01, z: -2}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 180}
   m_Children:
   - {fileID: 4000012994578320}
   m_Father: {fileID: 4000012009388676}
   m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 180}
 --- !u!4 &4000010242049322
 Transform:
   m_ObjectHideFlags: 1
@@ -2315,13 +2319,13 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 2, y: -2.0000002, z: 1.9999998}
   m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000011636893324}
   - {fileID: 4000011050292958}
   - {fileID: 4000013453137090}
   m_Father: {fileID: 4000013849328254}
   m_RootOrder: 23
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000010260882894
 Transform:
   m_ObjectHideFlags: 1
@@ -2331,13 +2335,13 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -2, y: 2.0000005, z: 2}
   m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000010416199044}
   - {fileID: 4000014143118706}
   - {fileID: 4000011983782742}
   m_Father: {fileID: 4000013849328254}
   m_RootOrder: 19
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000010327542202
 Transform:
   m_ObjectHideFlags: 1
@@ -2347,11 +2351,11 @@ Transform:
   m_LocalRotation: {x: 0.5, y: -0.5, z: 0.5, w: 0.5}
   m_LocalPosition: {x: 3.01, y: 2, z: 2}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 90}
   m_Children:
   - {fileID: 4000012222960206}
   m_Father: {fileID: 4000012009388676}
   m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 90}
 --- !u!4 &4000010353816684
 Transform:
   m_ObjectHideFlags: 1
@@ -2361,13 +2365,13 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 2, y: 2.0000002, z: 1.9999995}
   m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000010985990576}
   - {fileID: 4000010640655676}
   - {fileID: 4000012664039266}
   m_Father: {fileID: 4000013849328254}
   m_RootOrder: 17
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000010357744150
 Transform:
   m_ObjectHideFlags: 1
@@ -2377,11 +2381,11 @@ Transform:
   m_LocalRotation: {x: 0.5, y: -0.5, z: 0.5, w: 0.5}
   m_LocalPosition: {x: 3.01, y: -2, z: 2}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 90}
   m_Children:
   - {fileID: 4000012349687274}
   m_Father: {fileID: 4000012009388676}
   m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 90}
 --- !u!4 &4000010374669886
 Transform:
   m_ObjectHideFlags: 1
@@ -2391,10 +2395,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000011236259716}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000010389589316
 Transform:
   m_ObjectHideFlags: 1
@@ -2404,10 +2408,10 @@ Transform:
   m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000011949948730}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000010389731036
 Transform:
   m_ObjectHideFlags: 1
@@ -2417,12 +2421,12 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 2, y: 0, z: -1.9999998}
   m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000010790094764}
   - {fileID: 4000010605959690}
   m_Father: {fileID: 4000013849328254}
   m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000010395518844
 Transform:
   m_ObjectHideFlags: 1
@@ -2432,13 +2436,13 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -1.9999999, y: -2.0000005, z: 2.0000002}
   m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000013690353172}
   - {fileID: 4000011343104580}
   - {fileID: 4000014088704204}
   m_Father: {fileID: 4000013849328254}
   m_RootOrder: 25
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000010402675894
 Transform:
   m_ObjectHideFlags: 1
@@ -2448,12 +2452,12 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 2.8, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000011712990266}
   - {fileID: 4000013518515276}
   m_Father: {fileID: 4000010759135422}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000010416199044
 Transform:
   m_ObjectHideFlags: 1
@@ -2463,10 +2467,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000010260882894}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000010427142062
 Transform:
   m_ObjectHideFlags: 1
@@ -2476,10 +2480,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: -0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000013558227822}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000010537944402
 Transform:
   m_ObjectHideFlags: 1
@@ -2489,11 +2493,11 @@ Transform:
   m_LocalRotation: {x: 1, y: 0, z: 0, w: 0}
   m_LocalPosition: {x: -2, y: 3.01, z: -2}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 180}
   m_Children:
   - {fileID: 4000013878603692}
   m_Father: {fileID: 4000012009388676}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 180}
 --- !u!4 &4000010574272630
 Transform:
   m_ObjectHideFlags: 1
@@ -2503,11 +2507,11 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 2, y: 0, z: 0}
   m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000010898279106}
   m_Father: {fileID: 4000013849328254}
   m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000010605959690
 Transform:
   m_ObjectHideFlags: 1
@@ -2517,10 +2521,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: -0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000010389731036}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000010640655676
 Transform:
   m_ObjectHideFlags: 1
@@ -2530,10 +2534,10 @@ Transform:
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000010353816684}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000010656965664
 Transform:
   m_ObjectHideFlags: 1
@@ -2543,10 +2547,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000012441471684}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000010723032348
 Transform:
   m_ObjectHideFlags: 1
@@ -2556,10 +2560,10 @@ Transform:
   m_LocalRotation: {x: 1, y: 0, z: 0, w: -0.00000004371139}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000012006565106}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000010747608656
 Transform:
   m_ObjectHideFlags: 1
@@ -2569,12 +2573,12 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 2, z: 1.9999998}
   m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000011999091050}
   - {fileID: 4000012588663612}
   m_Father: {fileID: 4000013849328254}
   m_RootOrder: 18
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000010748016836
 Transform:
   m_ObjectHideFlags: 1
@@ -2584,10 +2588,10 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: 4.4408905e-16, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
   m_Children: []
   m_Father: {fileID: 4000013430938988}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
 --- !u!4 &4000010759135422
 Transform:
   m_ObjectHideFlags: 1
@@ -2597,7 +2601,6 @@ Transform:
   m_LocalRotation: {x: 0.4332655, y: 0.359558, z: 0.2528144, w: 0.7868189}
   m_LocalPosition: {x: 0, y: 0.09, z: 0}
   m_LocalScale: {x: 0.015, y: 0.015, z: 0.015}
-  m_LocalEulerAnglesHint: {x: 30, y: 65, z: 55}
   m_Children:
   - {fileID: 4000010402675894}
   - {fileID: 4000011757126956}
@@ -2605,6 +2608,7 @@ Transform:
   - {fileID: 4000012009388676}
   m_Father: {fileID: 474250}
   m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 30, y: 65, z: 55}
 --- !u!4 &4000010766034876
 Transform:
   m_ObjectHideFlags: 1
@@ -2614,10 +2618,10 @@ Transform:
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000011542102458}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000010790094764
 Transform:
   m_ObjectHideFlags: 1
@@ -2627,10 +2631,10 @@ Transform:
   m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000010389731036}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000010812395584
 Transform:
   m_ObjectHideFlags: 1
@@ -2640,10 +2644,10 @@ Transform:
   m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000011067675276}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000010815577572
 Transform:
   m_ObjectHideFlags: 1
@@ -2653,11 +2657,11 @@ Transform:
   m_LocalRotation: {x: 0.5, y: 0.5, z: 0.5, w: 0.5}
   m_LocalPosition: {x: 2, y: -2, z: -3.01}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 90}
   m_Children:
   - {fileID: 4000012087178338}
   m_Father: {fileID: 4000012009388676}
   m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 90}
 --- !u!4 &4000010840460470
 Transform:
   m_ObjectHideFlags: 1
@@ -2667,12 +2671,12 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: -2, z: -1.9999998}
   m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000012873274248}
   - {fileID: 4000011203728406}
   m_Father: {fileID: 4000013849328254}
   m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000010898279106
 Transform:
   m_ObjectHideFlags: 1
@@ -2682,10 +2686,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: -0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000010574272630}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000010933029818
 Transform:
   m_ObjectHideFlags: 1
@@ -2695,10 +2699,10 @@ Transform:
   m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000011108317162}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000010985990576
 Transform:
   m_ObjectHideFlags: 1
@@ -2708,10 +2712,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000010353816684}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000011012383888
 Transform:
   m_ObjectHideFlags: 1
@@ -2721,10 +2725,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000011949948730}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000011024939302
 Transform:
   m_ObjectHideFlags: 1
@@ -2734,11 +2738,11 @@ Transform:
   m_LocalRotation: {x: 0.5, y: -0.5, z: 0.5, w: 0.5}
   m_LocalPosition: {x: 3.01, y: 2, z: -2}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 90}
   m_Children:
   - {fileID: 4000010179322970}
   m_Father: {fileID: 4000012009388676}
   m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 90}
 --- !u!4 &4000011050292958
 Transform:
   m_ObjectHideFlags: 1
@@ -2748,10 +2752,10 @@ Transform:
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000010242049322}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000011059494508
 Transform:
   m_ObjectHideFlags: 1
@@ -2761,10 +2765,10 @@ Transform:
   m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000012050999054}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000011067675276
 Transform:
   m_ObjectHideFlags: 1
@@ -2774,13 +2778,13 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -2.0000002, y: 2.0000002, z: -1.9999998}
   m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000011769768434}
   - {fileID: 4000010812395584}
   - {fileID: 4000013885329996}
   m_Father: {fileID: 4000013849328254}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000011092773186
 Transform:
   m_ObjectHideFlags: 1
@@ -2790,10 +2794,10 @@ Transform:
   m_LocalRotation: {x: 1, y: 0, z: 0, w: -0.00000004371139}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000012003096180}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000011108317162
 Transform:
   m_ObjectHideFlags: 1
@@ -2803,12 +2807,12 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -2, y: 0, z: -1.9999995}
   m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000010933029818}
   - {fileID: 4000013261128892}
   m_Father: {fileID: 4000013849328254}
   m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000011203728406
 Transform:
   m_ObjectHideFlags: 1
@@ -2818,10 +2822,10 @@ Transform:
   m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000010840460470}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000011236259716
 Transform:
   m_ObjectHideFlags: 1
@@ -2831,13 +2835,13 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -2.0000002, y: -2.0000002, z: -1.9999995}
   m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000012458002360}
   - {fileID: 4000012725870104}
   - {fileID: 4000010374669886}
   m_Father: {fileID: 4000013849328254}
   m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000011343104580
 Transform:
   m_ObjectHideFlags: 1
@@ -2847,10 +2851,10 @@ Transform:
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000010395518844}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000011353769578
 Transform:
   m_ObjectHideFlags: 1
@@ -2860,10 +2864,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: -0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000013216064610}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000011410605652
 Transform:
   m_ObjectHideFlags: 1
@@ -2873,10 +2877,10 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: 4.4408905e-16, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
   m_Children: []
   m_Father: {fileID: 4000013959298910}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
 --- !u!4 &4000011542102458
 Transform:
   m_ObjectHideFlags: 1
@@ -2886,11 +2890,11 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 1.9999998}
   m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000010766034876}
   m_Father: {fileID: 4000013849328254}
   m_RootOrder: 21
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000011619460948
 Transform:
   m_ObjectHideFlags: 1
@@ -2900,12 +2904,12 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 2, y: 2.0000002, z: 0}
   m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000013913277266}
   - {fileID: 4000013748835054}
   m_Father: {fileID: 4000013849328254}
   m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000011636893324
 Transform:
   m_ObjectHideFlags: 1
@@ -2915,10 +2919,10 @@ Transform:
   m_LocalRotation: {x: 1, y: 0, z: 0, w: -0.00000004371139}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000010242049322}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000011712990266
 Transform:
   m_ObjectHideFlags: 1
@@ -2928,10 +2932,10 @@ Transform:
   m_LocalRotation: {x: 0.579228, y: -0.579228, z: -0.40557975, w: -0.40557975}
   m_LocalPosition: {x: 0.20806599, y: 0, z: -0}
   m_LocalScale: {x: 1.04, y: 0.0065, z: 0.78}
-  m_LocalEulerAnglesHint: {x: 250, y: 0, z: 90}
   m_Children: []
   m_Father: {fileID: 4000010402675894}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 250, y: 0, z: 90}
 --- !u!4 &4000011757126956
 Transform:
   m_ObjectHideFlags: 1
@@ -2941,10 +2945,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000010759135422}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000011760460316
 Transform:
   m_ObjectHideFlags: 1
@@ -2954,10 +2958,10 @@ Transform:
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000012006565106}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000011769768434
 Transform:
   m_ObjectHideFlags: 1
@@ -2967,10 +2971,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: -0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000011067675276}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000011783535876
 Transform:
   m_ObjectHideFlags: 1
@@ -2980,12 +2984,12 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -2.0000002, y: 0, z: 2}
   m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000013298190686}
   - {fileID: 4000013248361220}
   m_Father: {fileID: 4000013849328254}
   m_RootOrder: 22
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000011860622312
 Transform:
   m_ObjectHideFlags: 1
@@ -2995,10 +2999,10 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: 4.4408905e-16, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
   m_Children: []
   m_Father: {fileID: 4000014114397878}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
 --- !u!4 &4000011949948730
 Transform:
   m_ObjectHideFlags: 1
@@ -3008,12 +3012,12 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 2.0000002, z: -1.9999998}
   m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000011012383888}
   - {fileID: 4000010389589316}
   m_Father: {fileID: 4000013849328254}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000011983782742
 Transform:
   m_ObjectHideFlags: 1
@@ -3023,10 +3027,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000010260882894}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000011999091050
 Transform:
   m_ObjectHideFlags: 1
@@ -3036,10 +3040,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000010747608656}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000012003096180
 Transform:
   m_ObjectHideFlags: 1
@@ -3049,11 +3053,11 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: -2, z: 0}
   m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000011092773186}
   m_Father: {fileID: 4000013849328254}
   m_RootOrder: 15
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000012006565106
 Transform:
   m_ObjectHideFlags: 1
@@ -3063,12 +3067,12 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: -2.0000002, z: 1.9999998}
   m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000010723032348}
   - {fileID: 4000011760460316}
   m_Father: {fileID: 4000013849328254}
   m_RootOrder: 24
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000012009388676
 Transform:
   m_ObjectHideFlags: 1
@@ -3078,7 +3082,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000014222402742}
   - {fileID: 4000014114397878}
@@ -3094,6 +3097,7 @@ Transform:
   - {fileID: 4000014289868594}
   m_Father: {fileID: 4000010759135422}
   m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000012050999054
 Transform:
   m_ObjectHideFlags: 1
@@ -3103,11 +3107,11 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: -1.9999998}
   m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000011059494508}
   m_Father: {fileID: 4000013849328254}
   m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000012078948898
 Transform:
   m_ObjectHideFlags: 1
@@ -3117,11 +3121,11 @@ Transform:
   m_LocalRotation: {x: 0.5, y: 0.5, z: 0.5, w: 0.5}
   m_LocalPosition: {x: -2, y: 2, z: -3.01}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 90}
   m_Children:
   - {fileID: 4000013349972066}
   m_Father: {fileID: 4000012009388676}
   m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 90}
 --- !u!4 &4000012087178338
 Transform:
   m_ObjectHideFlags: 1
@@ -3131,10 +3135,10 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: 4.4408905e-16, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
   m_Children: []
   m_Father: {fileID: 4000010815577572}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
 --- !u!4 &4000012151036550
 Transform:
   m_ObjectHideFlags: 1
@@ -3144,10 +3148,10 @@ Transform:
   m_LocalRotation: {x: 1, y: 0, z: 0, w: -0.00000004371139}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000012700339238}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000012168034430
 Transform:
   m_ObjectHideFlags: 1
@@ -3157,11 +3161,11 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -2.0000002, y: 0, z: 0}
   m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000014126019588}
   m_Father: {fileID: 4000013849328254}
   m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000012222960206
 Transform:
   m_ObjectHideFlags: 1
@@ -3171,10 +3175,10 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: 4.4408905e-16, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
   m_Children: []
   m_Father: {fileID: 4000010327542202}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
 --- !u!4 &4000012349687274
 Transform:
   m_ObjectHideFlags: 1
@@ -3184,10 +3188,10 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: 4.4408905e-16, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
   m_Children: []
   m_Father: {fileID: 4000010357744150}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
 --- !u!4 &4000012441471684
 Transform:
   m_ObjectHideFlags: 1
@@ -3197,13 +3201,13 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 2.0000002, y: 2, z: -2.0000002}
   m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000010656965664}
   - {fileID: 4000013738885272}
   - {fileID: 4000013641552310}
   m_Father: {fileID: 4000013849328254}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000012458002360
 Transform:
   m_ObjectHideFlags: 1
@@ -3213,10 +3217,10 @@ Transform:
   m_LocalRotation: {x: 1, y: 0, z: 0, w: -0.00000004371139}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000011236259716}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000012498516904
 Transform:
   m_ObjectHideFlags: 1
@@ -3226,10 +3230,10 @@ Transform:
   m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000013216064610}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000012588663612
 Transform:
   m_ObjectHideFlags: 1
@@ -3239,10 +3243,10 @@ Transform:
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000010747608656}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000012664039266
 Transform:
   m_ObjectHideFlags: 1
@@ -3252,10 +3256,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: -0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000010353816684}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000012700339238
 Transform:
   m_ObjectHideFlags: 1
@@ -3265,12 +3269,12 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 2, y: -2.0000005, z: 0}
   m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000012151036550}
   - {fileID: 4000013710424504}
   m_Father: {fileID: 4000013849328254}
   m_RootOrder: 14
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000012725870104
 Transform:
   m_ObjectHideFlags: 1
@@ -3280,10 +3284,10 @@ Transform:
   m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000011236259716}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000012777973900
 Transform:
   m_ObjectHideFlags: 1
@@ -3293,10 +3297,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000013230975600}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000012873274248
 Transform:
   m_ObjectHideFlags: 1
@@ -3306,10 +3310,10 @@ Transform:
   m_LocalRotation: {x: 1, y: 0, z: 0, w: -0.00000004371139}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000010840460470}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000012929691494
 Transform:
   m_ObjectHideFlags: 1
@@ -3319,10 +3323,10 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: 4.4408905e-16, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
   m_Children: []
   m_Father: {fileID: 4000014289868594}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
 --- !u!4 &4000012931313718
 Transform:
   m_ObjectHideFlags: 1
@@ -3332,10 +3336,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000013688063632}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000012994578320
 Transform:
   m_ObjectHideFlags: 1
@@ -3345,10 +3349,10 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: 4.4408905e-16, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
   m_Children: []
   m_Father: {fileID: 4000010214419708}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
 --- !u!4 &4000013216064610
 Transform:
   m_ObjectHideFlags: 1
@@ -3358,13 +3362,13 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 2, y: -2.0000005, z: -2}
   m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000014084031438}
   - {fileID: 4000012498516904}
   - {fileID: 4000011353769578}
   m_Father: {fileID: 4000013849328254}
   m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000013230975600
 Transform:
   m_ObjectHideFlags: 1
@@ -3374,12 +3378,12 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -2.0000002, y: -2.0000002, z: 0}
   m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000013861139206}
   - {fileID: 4000012777973900}
   m_Father: {fileID: 4000013849328254}
   m_RootOrder: 16
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000013248361220
 Transform:
   m_ObjectHideFlags: 1
@@ -3389,10 +3393,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000011783535876}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000013261128892
 Transform:
   m_ObjectHideFlags: 1
@@ -3402,10 +3406,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000011108317162}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000013272657826
 Transform:
   m_ObjectHideFlags: 1
@@ -3415,10 +3419,10 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: 4.4408905e-16, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
   m_Children: []
   m_Father: {fileID: 4000014222402742}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
 --- !u!4 &4000013298190686
 Transform:
   m_ObjectHideFlags: 1
@@ -3428,10 +3432,10 @@ Transform:
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000011783535876}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000013349972066
 Transform:
   m_ObjectHideFlags: 1
@@ -3441,10 +3445,10 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: 4.4408905e-16, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
   m_Children: []
   m_Father: {fileID: 4000012078948898}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
 --- !u!4 &4000013430938988
 Transform:
   m_ObjectHideFlags: 1
@@ -3454,11 +3458,11 @@ Transform:
   m_LocalRotation: {x: 0.5, y: 0.5, z: 0.5, w: 0.5}
   m_LocalPosition: {x: 2, y: 2, z: -3.01}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 90}
   m_Children:
   - {fileID: 4000010748016836}
   m_Father: {fileID: 4000012009388676}
   m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 90}
 --- !u!4 &4000013453137090
 Transform:
   m_ObjectHideFlags: 1
@@ -3468,10 +3472,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: -0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000010242049322}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000013518515276
 Transform:
   m_ObjectHideFlags: 1
@@ -3481,10 +3485,10 @@ Transform:
   m_LocalRotation: {x: 0.40557975, y: 0.40557975, z: -0.579228, w: 0.579228}
   m_LocalPosition: {x: 0.013, y: -0.065, z: -0}
   m_LocalScale: {x: 0.065, y: 0.065, z: 0.065}
-  m_LocalEulerAnglesHint: {x: 70, y: 0, z: -90}
   m_Children: []
   m_Father: {fileID: 4000010402675894}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 70, y: 0, z: -90}
 --- !u!4 &4000013558227822
 Transform:
   m_ObjectHideFlags: 1
@@ -3494,12 +3498,12 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 2, y: 0, z: 1.9999995}
   m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000010018887462}
   - {fileID: 4000010427142062}
   m_Father: {fileID: 4000013849328254}
   m_RootOrder: 20
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000013641552310
 Transform:
   m_ObjectHideFlags: 1
@@ -3509,10 +3513,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: -0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000012441471684}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000013688063632
 Transform:
   m_ObjectHideFlags: 1
@@ -3522,12 +3526,12 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -2.0000002, y: 2.0000005, z: 0}
   m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000013821416868}
   - {fileID: 4000012931313718}
   m_Father: {fileID: 4000013849328254}
   m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000013690353172
 Transform:
   m_ObjectHideFlags: 1
@@ -3537,10 +3541,10 @@ Transform:
   m_LocalRotation: {x: 1, y: 0, z: 0, w: -0.00000004371139}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000010395518844}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000013710424504
 Transform:
   m_ObjectHideFlags: 1
@@ -3550,10 +3554,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: -0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000012700339238}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000013734051952
 Transform:
   m_ObjectHideFlags: 1
@@ -3563,10 +3567,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000014054861136}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000013738885272
 Transform:
   m_ObjectHideFlags: 1
@@ -3576,10 +3580,10 @@ Transform:
   m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000012441471684}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000013748835054
 Transform:
   m_ObjectHideFlags: 1
@@ -3589,10 +3593,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: -0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000011619460948}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000013821416868
 Transform:
   m_ObjectHideFlags: 1
@@ -3602,10 +3606,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000013688063632}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000013849328254
 Transform:
   m_ObjectHideFlags: 1
@@ -3615,7 +3619,6 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0.000000014901159, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1.0000001, z: 1.0000002}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000012441471684}
   - {fileID: 4000011949948730}
@@ -3645,6 +3648,7 @@ Transform:
   - {fileID: 4000010395518844}
   m_Father: {fileID: 4000010759135422}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000013861139206
 Transform:
   m_ObjectHideFlags: 1
@@ -3654,10 +3658,10 @@ Transform:
   m_LocalRotation: {x: 1, y: 0, z: 0, w: -0.00000004371139}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000013230975600}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000013878603692
 Transform:
   m_ObjectHideFlags: 1
@@ -3667,10 +3671,10 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: 4.4408905e-16, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
   m_Children: []
   m_Father: {fileID: 4000010537944402}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
 --- !u!4 &4000013885329996
 Transform:
   m_ObjectHideFlags: 1
@@ -3680,10 +3684,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000011067675276}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000013913277266
 Transform:
   m_ObjectHideFlags: 1
@@ -3693,10 +3697,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000011619460948}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000013959298910
 Transform:
   m_ObjectHideFlags: 1
@@ -3706,11 +3710,11 @@ Transform:
   m_LocalRotation: {x: 1, y: 0, z: 0, w: 0}
   m_LocalPosition: {x: -2, y: 3.01, z: 2}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 180}
   m_Children:
   - {fileID: 4000011410605652}
   m_Father: {fileID: 4000012009388676}
   m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 180}
 --- !u!4 &4000014054861136
 Transform:
   m_ObjectHideFlags: 1
@@ -3720,11 +3724,11 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 2, z: 0}
   m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000013734051952}
   m_Father: {fileID: 4000013849328254}
   m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000014084031438
 Transform:
   m_ObjectHideFlags: 1
@@ -3734,10 +3738,10 @@ Transform:
   m_LocalRotation: {x: 1, y: 0, z: 0, w: -0.00000004371139}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000013216064610}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000014088704204
 Transform:
   m_ObjectHideFlags: 1
@@ -3747,10 +3751,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000010395518844}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000014114397878
 Transform:
   m_ObjectHideFlags: 1
@@ -3760,11 +3764,11 @@ Transform:
   m_LocalRotation: {x: 0.5, y: 0.5, z: 0.5, w: 0.5}
   m_LocalPosition: {x: -2, y: -2, z: -3.01}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 90}
   m_Children:
   - {fileID: 4000011860622312}
   m_Father: {fileID: 4000012009388676}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 90}
 --- !u!4 &4000014126019588
 Transform:
   m_ObjectHideFlags: 1
@@ -3774,10 +3778,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000012168034430}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000014143118706
 Transform:
   m_ObjectHideFlags: 1
@@ -3787,10 +3791,10 @@ Transform:
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000010260882894}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4000014222402742
 Transform:
   m_ObjectHideFlags: 1
@@ -3800,11 +3804,11 @@ Transform:
   m_LocalRotation: {x: 0.5, y: -0.5, z: 0.5, w: 0.5}
   m_LocalPosition: {x: 3.01, y: -2, z: -2}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 90}
   m_Children:
   - {fileID: 4000013272657826}
   m_Father: {fileID: 4000012009388676}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 90}
 --- !u!4 &4000014289868594
 Transform:
   m_ObjectHideFlags: 1
@@ -3814,11 +3818,11 @@ Transform:
   m_LocalRotation: {x: 1, y: 0, z: 0, w: 0}
   m_LocalPosition: {x: 2, y: 3.01, z: 2}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 180}
   m_Children:
   - {fileID: 4000012929691494}
   m_Father: {fileID: 4000012009388676}
   m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 180}
 --- !u!23 &23000010019435540
 MeshRenderer:
   m_ObjectHideFlags: 1
@@ -3833,7 +3837,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a78e23ea90ca04f4a8455e36fdbdee64, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -3841,12 +3847,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000010152233454
 MeshRenderer:
@@ -3862,7 +3869,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a78e23ea90ca04f4a8455e36fdbdee64, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -3870,12 +3879,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000010182591898
 MeshRenderer:
@@ -3891,7 +3901,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a78e23ea90ca04f4a8455e36fdbdee64, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -3899,12 +3911,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000010332892714
 MeshRenderer:
@@ -3920,7 +3933,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: c67f383e3e108474ab1245c39296a3bb, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -3928,12 +3943,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000010416953104
 MeshRenderer:
@@ -3949,7 +3965,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -3957,12 +3975,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000010423174614
 MeshRenderer:
@@ -3978,7 +3997,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a78e23ea90ca04f4a8455e36fdbdee64, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -3986,12 +4007,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000010443646980
 MeshRenderer:
@@ -4007,7 +4029,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 3c56d54deede7ff4c903302accba3732, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4015,12 +4039,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000010497134790
 MeshRenderer:
@@ -4036,7 +4061,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: c67f383e3e108474ab1245c39296a3bb, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4044,12 +4071,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000010507217582
 MeshRenderer:
@@ -4065,7 +4093,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: deda35d961bb56d4ea329a99094520b1, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4073,12 +4103,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000010525892768
 MeshRenderer:
@@ -4094,7 +4125,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4102,12 +4135,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000010542011170
 MeshRenderer:
@@ -4123,7 +4157,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4131,12 +4167,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000010585640078
 MeshRenderer:
@@ -4152,7 +4189,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 3c05793de009bfb4ba7fa94fa2b39a1a, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4160,12 +4199,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000010663999318
 MeshRenderer:
@@ -4181,7 +4221,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 3c56d54deede7ff4c903302accba3732, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4189,12 +4231,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000010669993228
 MeshRenderer:
@@ -4210,7 +4253,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 873e8d79c201b1747938d94c9f5c9e93, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4218,12 +4263,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000010670157426
 MeshRenderer:
@@ -4239,7 +4285,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 43aaa69d63fda10448dba1b885868583, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4247,12 +4295,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000010677518874
 MeshRenderer:
@@ -4268,7 +4317,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 43aaa69d63fda10448dba1b885868583, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4276,12 +4327,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000010799551746
 MeshRenderer:
@@ -4297,7 +4349,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4305,12 +4359,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000010837334206
 MeshRenderer:
@@ -4326,7 +4381,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4334,12 +4391,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000010938276878
 MeshRenderer:
@@ -4355,7 +4413,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4363,12 +4423,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000010959930140
 MeshRenderer:
@@ -4384,7 +4445,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4392,12 +4455,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000010986005014
 MeshRenderer:
@@ -4413,7 +4477,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 3c56d54deede7ff4c903302accba3732, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4421,12 +4487,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011007433384
 MeshRenderer:
@@ -4442,7 +4509,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 3c56d54deede7ff4c903302accba3732, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4450,12 +4519,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011022109152
 MeshRenderer:
@@ -4471,7 +4541,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: deda35d961bb56d4ea329a99094520b1, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4479,12 +4551,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011029076442
 MeshRenderer:
@@ -4500,7 +4573,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: c67f383e3e108474ab1245c39296a3bb, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4508,12 +4583,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011061961808
 MeshRenderer:
@@ -4529,7 +4605,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 3c05793de009bfb4ba7fa94fa2b39a1a, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4537,12 +4615,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011091832898
 MeshRenderer:
@@ -4558,7 +4637,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 3c56d54deede7ff4c903302accba3732, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4566,12 +4647,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011095039286
 MeshRenderer:
@@ -4587,7 +4669,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a78e23ea90ca04f4a8455e36fdbdee64, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4595,12 +4679,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011104732210
 MeshRenderer:
@@ -4616,7 +4701,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4624,12 +4711,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011154186656
 MeshRenderer:
@@ -4645,7 +4733,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 3c56d54deede7ff4c903302accba3732, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4653,12 +4743,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011174510226
 MeshRenderer:
@@ -4674,7 +4765,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4682,12 +4775,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011219514246
 MeshRenderer:
@@ -4703,7 +4797,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: deda35d961bb56d4ea329a99094520b1, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4711,12 +4807,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011228606762
 MeshRenderer:
@@ -4732,7 +4829,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 873e8d79c201b1747938d94c9f5c9e93, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4740,12 +4839,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011249616576
 MeshRenderer:
@@ -4761,7 +4861,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: c67f383e3e108474ab1245c39296a3bb, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4769,12 +4871,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011256254906
 MeshRenderer:
@@ -4790,7 +4893,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: deda35d961bb56d4ea329a99094520b1, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4798,12 +4903,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011273551432
 MeshRenderer:
@@ -4819,7 +4925,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 43aaa69d63fda10448dba1b885868583, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4827,12 +4935,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011368981806
 MeshRenderer:
@@ -4848,7 +4957,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4856,12 +4967,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011383030498
 MeshRenderer:
@@ -4877,7 +4989,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 3c05793de009bfb4ba7fa94fa2b39a1a, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4885,12 +4999,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011435996572
 MeshRenderer:
@@ -4906,7 +5021,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 3c05793de009bfb4ba7fa94fa2b39a1a, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4914,12 +5031,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011439698592
 MeshRenderer:
@@ -4935,7 +5053,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4943,12 +5063,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011455418576
 MeshRenderer:
@@ -4964,7 +5085,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -4972,12 +5095,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011635541786
 MeshRenderer:
@@ -4993,7 +5117,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 43aaa69d63fda10448dba1b885868583, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5001,12 +5127,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011649196236
 MeshRenderer:
@@ -5022,7 +5149,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: deda35d961bb56d4ea329a99094520b1, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5030,12 +5159,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011651382512
 MeshRenderer:
@@ -5051,7 +5181,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5059,12 +5191,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011686379044
 MeshRenderer:
@@ -5080,7 +5213,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 3c05793de009bfb4ba7fa94fa2b39a1a, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5088,12 +5223,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011698701706
 MeshRenderer:
@@ -5109,7 +5245,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: c67f383e3e108474ab1245c39296a3bb, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5117,12 +5255,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011727584160
 MeshRenderer:
@@ -5138,7 +5277,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5146,12 +5287,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011732654848
 MeshRenderer:
@@ -5167,7 +5309,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 3c05793de009bfb4ba7fa94fa2b39a1a, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5175,12 +5319,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000011785937136
 MeshRenderer:
@@ -5196,7 +5341,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5204,12 +5351,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000012176563066
 MeshRenderer:
@@ -5225,7 +5373,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 873e8d79c201b1747938d94c9f5c9e93, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5233,12 +5383,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000012253316974
 MeshRenderer:
@@ -5254,7 +5405,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: c67f383e3e108474ab1245c39296a3bb, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5262,12 +5415,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000012330836776
 MeshRenderer:
@@ -5283,7 +5437,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 43aaa69d63fda10448dba1b885868583, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5291,12 +5447,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000012346037064
 MeshRenderer:
@@ -5312,7 +5469,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5320,12 +5479,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000012389412998
 MeshRenderer:
@@ -5341,7 +5501,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 43aaa69d63fda10448dba1b885868583, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5349,12 +5511,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000012400344774
 MeshRenderer:
@@ -5370,7 +5533,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 3c56d54deede7ff4c903302accba3732, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5378,12 +5543,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000012431294952
 MeshRenderer:
@@ -5399,7 +5565,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5407,12 +5575,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000012446562360
 MeshRenderer:
@@ -5428,7 +5597,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5436,12 +5607,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000012461839264
 MeshRenderer:
@@ -5457,7 +5629,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 873e8d79c201b1747938d94c9f5c9e93, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5465,12 +5639,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000012475012704
 MeshRenderer:
@@ -5486,7 +5661,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 43aaa69d63fda10448dba1b885868583, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5494,12 +5671,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000012476740840
 MeshRenderer:
@@ -5515,7 +5693,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 43aaa69d63fda10448dba1b885868583, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5523,12 +5703,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000012478539362
 MeshRenderer:
@@ -5544,7 +5725,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 873e8d79c201b1747938d94c9f5c9e93, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5552,12 +5735,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000012481975348
 MeshRenderer:
@@ -5573,7 +5757,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 3c05793de009bfb4ba7fa94fa2b39a1a, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5581,12 +5767,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000012658364258
 MeshRenderer:
@@ -5602,7 +5789,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 3c56d54deede7ff4c903302accba3732, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5610,12 +5799,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000012660143542
 MeshRenderer:
@@ -5631,7 +5821,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 873e8d79c201b1747938d94c9f5c9e93, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5639,12 +5831,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000012685712688
 MeshRenderer:
@@ -5660,7 +5853,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 873e8d79c201b1747938d94c9f5c9e93, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5668,12 +5863,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000012717694236
 MeshRenderer:
@@ -5689,7 +5885,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: c67f383e3e108474ab1245c39296a3bb, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5697,12 +5895,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000012741528876
 MeshRenderer:
@@ -5718,7 +5917,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: deda35d961bb56d4ea329a99094520b1, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5726,12 +5927,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000012754193118
 MeshRenderer:
@@ -5747,7 +5949,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 3c56d54deede7ff4c903302accba3732, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5755,12 +5959,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000012763507068
 MeshRenderer:
@@ -5776,7 +5981,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a78e23ea90ca04f4a8455e36fdbdee64, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5784,12 +5991,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000012781332370
 MeshRenderer:
@@ -5805,7 +6013,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5813,12 +6023,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000012954480808
 MeshRenderer:
@@ -5834,7 +6045,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: deda35d961bb56d4ea329a99094520b1, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5842,12 +6055,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000013014842766
 MeshRenderer:
@@ -5863,7 +6077,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5871,12 +6087,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000013015702288
 MeshRenderer:
@@ -5892,7 +6109,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 3c05793de009bfb4ba7fa94fa2b39a1a, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5900,12 +6119,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000013072819516
 MeshRenderer:
@@ -5921,7 +6141,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 3c05793de009bfb4ba7fa94fa2b39a1a, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5929,12 +6151,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000013107182616
 MeshRenderer:
@@ -5950,7 +6173,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: deda35d961bb56d4ea329a99094520b1, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5958,12 +6183,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000013117716366
 MeshRenderer:
@@ -5979,7 +6205,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 3c05793de009bfb4ba7fa94fa2b39a1a, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -5987,12 +6215,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000013169679094
 MeshRenderer:
@@ -6008,7 +6237,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a78e23ea90ca04f4a8455e36fdbdee64, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -6016,12 +6247,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000013293873462
 MeshRenderer:
@@ -6037,7 +6269,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a78e23ea90ca04f4a8455e36fdbdee64, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -6045,12 +6279,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000013349277184
 MeshRenderer:
@@ -6066,7 +6301,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: deda35d961bb56d4ea329a99094520b1, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -6074,12 +6311,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000013421017940
 MeshRenderer:
@@ -6095,7 +6333,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 43aaa69d63fda10448dba1b885868583, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -6103,12 +6343,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000013575804314
 MeshRenderer:
@@ -6124,7 +6365,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 873e8d79c201b1747938d94c9f5c9e93, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -6132,12 +6375,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000013580629118
 MeshRenderer:
@@ -6153,7 +6397,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -6161,12 +6407,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000013589934874
 MeshRenderer:
@@ -6182,7 +6429,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -6190,12 +6439,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000013655333500
 MeshRenderer:
@@ -6211,7 +6461,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 873e8d79c201b1747938d94c9f5c9e93, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -6219,12 +6471,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000013780545214
 MeshRenderer:
@@ -6240,7 +6493,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 3c05793de009bfb4ba7fa94fa2b39a1a, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -6248,12 +6503,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000013864311222
 MeshRenderer:
@@ -6269,7 +6525,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: c67f383e3e108474ab1245c39296a3bb, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -6277,12 +6535,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000013890717450
 MeshRenderer:
@@ -6298,7 +6557,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -6306,12 +6567,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000013945920958
 MeshRenderer:
@@ -6327,7 +6589,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -6335,12 +6599,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000013958927208
 MeshRenderer:
@@ -6356,7 +6621,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 3c05793de009bfb4ba7fa94fa2b39a1a, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -6364,12 +6631,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000013987257600
 MeshRenderer:
@@ -6385,7 +6653,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: c67f383e3e108474ab1245c39296a3bb, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -6393,12 +6663,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000014001124402
 MeshRenderer:
@@ -6414,7 +6685,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a78e23ea90ca04f4a8455e36fdbdee64, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -6422,12 +6695,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000014233347352
 MeshRenderer:
@@ -6443,7 +6717,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -6451,12 +6727,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000014269021472
 MeshRenderer:
@@ -6472,7 +6749,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -6480,12 +6759,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!23 &23000014277856836
 MeshRenderer:
@@ -6501,7 +6781,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: a7f2c13d5d6dfc54888068a08ea0febd, type: 2}
-  m_SubsetIndices: 
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
@@ -6509,12 +6791,13 @@ MeshRenderer:
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
+  m_SelectedEditorRenderState: 3
   m_MinimumChartSize: 4
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!33 &33000010044614594
 MeshFilter:
@@ -8619,6 +8902,7 @@ MonoBehaviour:
   Bomb: {fileID: 11489324}
   Module: {fileID: 11429752}
   Audio: {fileID: 11496072}
+  Settings: {fileID: 114751797066452508}
   MainSelectable: {fileID: 11420650}
   Reset: {fileID: 114000013702621918}
   Pushers:
@@ -8975,3 +9259,16 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ShaderNames:
   - Legacy Shaders/Diffuse
+--- !u!114 &114751797066452508
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 127088}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -289456416, guid: 45b809be76fd7a3468b6f517bced6f28, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Settings: 
+  SettingsPath: 

--- a/Assets/TestHarness/TestHarness.prefab
+++ b/Assets/TestHarness/TestHarness.prefab
@@ -24,9 +24,10 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 101964}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0.0035797693, y: 0.041477196, z: -0.0068158545}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 224632491435617520}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -41,6 +42,91 @@ Prefab:
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 101964}
   m_IsPrefabParent: 1
+--- !u!1 &1083358106889498
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224157546098696694}
+  - component: {fileID: 20183571507019888}
+  - component: {fileID: 124509712377896352}
+  - component: {fileID: 92595605125315770}
+  - component: {fileID: 81520264578531030}
+  - component: {fileID: 222791563459554690}
+  m_Layer: 0
+  m_Name: Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1325717231613508
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224632491435617520}
+  m_Layer: 0
+  m_Name: TwitchPlaysCamera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!20 &20183571507019888
+Camera:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1083358106889498}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0.84
+    y: 0.56
+    width: 0.16
+    height: 0.28
+  near clip plane: 0.01
+  far clip plane: 3
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 100
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 0
+  m_AllowMSAA: 1
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+  m_StereoMirrorMode: 0
+--- !u!81 &81520264578531030
+AudioListener:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1083358106889498}
+  m_Enabled: 1
+--- !u!92 &92595605125315770
+Behaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1083358106889498}
+  m_Enabled: 1
 --- !u!114 &114617884380056244
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -67,4 +153,55 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   HighlightPrefab: {fileID: 100000, guid: d78a484c6e87f1b47b6596ac080fe942, type: 2}
+  TwitchPlaysCameraTransform: {fileID: 224632491435617520}
   AudioClips: []
+--- !u!124 &124509712377896352
+Behaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1083358106889498}
+  m_Enabled: 1
+--- !u!222 &222791563459554690
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1083358106889498}
+--- !u!224 &224157546098696694
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1083358106889498}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 224632491435617520}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.001, y: 0.3}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224632491435617520
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1325717231613508}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.0068158545}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 224157546098696694}
+  m_Father: {fileID: 439642}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -0.0035797693, y: -0.041477196}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 1, y: 1}

--- a/Assets/modSettings.json
+++ b/Assets/modSettings.json
@@ -1,0 +1,6 @@
+{
+  "HowToUse1": "This Setting determines how the Cube rotation works in Twitch Plays",
+  "HowToUse2": "The original method Rotates the bomb in order to view the cube sides. (and as of now, whatever side camera view that is active on that module)",
+  "HowToUse3": "The New method actually rotates the cube itself in order to view the sides.",
+  "UseOriginalTwitchPlaysRotationMethod": true
+}

--- a/Assets/modSettings.json.meta
+++ b/Assets/modSettings.json.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c452888803600104ba217f7f1fd9b206
+timeCreated: 1516663288
+licenseType: Pro
+TextScriptImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Now supports both the original style, and the style that was "shimmed",
configurable via settings.  default is original style.

Updated the test harness with the changes to simulate a single module camera view.  Also made it a requirement that you actually click on one of the modules that you wish to send the twitch play command to.  (It no longer sends them to ALL modules on the test scene.)

Test harness also now looks for KMModSettings.json on a module, and if present, initializes it.

If you wish to make the new style rotation default, feel free to change the code, and the included modsetting.json